### PR TITLE
Fix typo in gget/SKILL.md description

### DIFF
--- a/scientific-skills/gget/SKILL.md
+++ b/scientific-skills/gget/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gget
-description: Fast CLI/Python queries to 20+ bioinformatics databases. Use for quick lookups: gene info, BLAST searches, AlphaFold structures, enrichment analysis. Best for interactive exploration, simple queries. For batch processing or advanced BLAST use biopython; for multi-database Python workflows use bioservices.
+description: "Fast CLI/Python queries to 20+ bioinformatics databases. Use for quick lookups: gene info, BLAST searches, AlphaFold structures, enrichment analysis. Best for interactive exploration, simple queries. For batch processing or advanced BLAST use biopython; for multi-database Python workflows use bioservices."
 license: BSD-2-Clause license
 metadata:
     skill-author: K-Dense Inc.


### PR DESCRIPTION
Fix YAML syntax error in gget SKILL.md description

Summary

Fixed invalid YAML syntax in the gget SKILL.md that was preventing the skill from loading properly.

Changes

- Wrapped the description field value in quotes to escape the colon in "lookups:"
- The unquoted colon at column 92 was being interpreted as a YAML mapping operator, causing a parse error