### PR TITLE
fix(security): Replace shell=True with safe subprocess patterns in documentation

### DIFF
--- a/scientific-skills/alphafold-database/SKILL.md
+++ b/scientific-skills/alphafold-database/SKILL.md
@@ -238,14 +238,21 @@ print(f"Found {len(results)} high-confidence human proteins")
 
 **Download by Species:**
 
+> ⚠️ **Security Note**: The example below uses `shell=True` for simplicity. In production environments, prefer using `subprocess.run()` with a list of arguments to prevent command injection vulnerabilities. See [Python subprocess security](https://docs.python.org/3/library/subprocess.html#security-considerations).
+
 ```python
 import subprocess
+import shlex
 
 def download_proteome(taxonomy_id, output_dir="./proteomes"):
     """Download all AlphaFold predictions for a species"""
+    # Validate taxonomy_id is an integer to prevent injection
+    if not isinstance(taxonomy_id, int):
+        raise ValueError("taxonomy_id must be an integer")
+    
     pattern = f"gs://public-datasets-deepmind-alphafold-v4/proteomes/proteome-tax_id-{taxonomy_id}-*_v4.tar"
-    cmd = f"gsutil -m cp {pattern} {output_dir}/"
-    subprocess.run(cmd, shell=True, check=True)
+    # Use list form instead of shell=True for security
+    subprocess.run(["gsutil", "-m", "cp", pattern, f"{output_dir}/"], check=True)
 
 # Download E. coli proteome (tax ID: 83333)
 download_proteome(83333)

--- a/scientific-skills/modal/references/web-endpoints.md
+++ b/scientific-skills/modal/references/web-endpoints.md
@@ -131,6 +131,8 @@ def flask_app():
 
 For frameworks with custom network binding:
 
+> ⚠️ **Security Note**: The example below uses `shell=True` for simplicity. In production environments, prefer using `subprocess.Popen()` with a list of arguments to prevent command injection vulnerabilities.
+
 ```python
 @app.function()
 @modal.concurrent(max_inputs=100)
@@ -138,7 +140,8 @@ For frameworks with custom network binding:
 def my_server():
     import subprocess
     # Must bind to 0.0.0.0, not 127.0.0.1
-    subprocess.Popen("python -m http.server -d / 8000", shell=True)
+    # Use list form instead of shell=True for security
+    subprocess.Popen(["python", "-m", "http.server", "-d", "/", "8000"])
 ```
 
 ## Streaming Responses


### PR DESCRIPTION
## Summary

Fix command injection vulnerabilities in documentation examples by replacing `shell=True` with safe list-based subprocess calls.

## 🔴 Security Issue

Using `shell=True` with user-provided or interpolated strings can lead to command injection vulnerabilities. Users who copy these examples may inadvertently introduce security risks in their code.

## Changes

### `scientific-skills/alphafold-database/SKILL.md`

**Before:**
```python
cmd = f"gsutil -m cp {pattern} {output_dir}/"
subprocess.run(cmd, shell=True, check=True)
```

**After:**
```python
# Validate taxonomy_id is an integer to prevent injection
if not isinstance(taxonomy_id, int):
    raise ValueError("taxonomy_id must be an integer")

# Use list form instead of shell=True for security
subprocess.run(["gsutil", "-m", "cp", pattern, f"{output_dir}/"], check=True)
```

### `scientific-skills/modal/references/web-endpoints.md`

**Before:**
```python
subprocess.Popen("python -m http.server -d / 8000", shell=True)
```

**After:**
```python
# Use list form instead of shell=True for security
subprocess.Popen(["python", "-m", "http.server", "-d", "/", "8000"])
```

## Security Notes Added

Both files now include a security warning:

> ⚠️ **Security Note**: The example below uses `shell=True` for simplicity. In production environments, prefer using `subprocess.run()` with a list of arguments to prevent command injection vulnerabilities.

## References

- [CWE-78: Improper Neutralization of Special Elements used in an OS Command](https://cwe.mitre.org/data/definitions/78.html)
- [Python subprocess security considerations](https://docs.python.org/3/library/subprocess.html#security-considerations)