### PR TITLE
Add patentsview api key for patent search api

### DIFF
--- a/scientific-skills/uspto-database/SKILL.md
+++ b/scientific-skills/uspto-database/SKILL.md
@@ -66,12 +66,16 @@ The USPTO provides multiple specialized APIs for different data needs:
 
 ### API Key Registration
 
-All USPTO APIs require an API key. Register at:
+USPTO APIs require an API key. Register at:
 **https://account.uspto.gov/api-manager/**
+
+API key for **PatentSearch API** is provided by PatentsView. Register at:
+**https://patentsview.org/api-v01-information-page**
 
 Set the API key as an environment variable:
 ```bash
 export USPTO_API_KEY="your_api_key_here"
+export PATENTSVIEW_API_KEY="you_api_key_here"
 ```
 
 ### Helper Scripts
@@ -98,7 +102,7 @@ client = PatentSearchClient()
 
 # Search for machine learning patents
 results = client.search_patents({
-    "patent_abstract": {"_text_all": ["machine", "learning"]}
+    "_text_all": {"patent_abstract": "machine learning"}
 })
 
 for patent in results['patents']:

--- a/scientific-skills/uspto-database/scripts/patent_search.py
+++ b/scientific-skills/uspto-database/scripts/patent_search.py
@@ -31,11 +31,11 @@ class PatentSearchClient:
         Initialize client with API key.
 
         Args:
-            api_key: USPTO API key (if not provided, uses USPTO_API_KEY env var)
+            api_key: PatentsView API key (if not provided, uses PATENTSVIEW_API_KEY env var)
         """
-        self.api_key = api_key or os.getenv("USPTO_API_KEY")
+        self.api_key = api_key or os.getenv("PATENTSVIEW_API_KEY")
         if not self.api_key:
-            raise ValueError("API key required. Set USPTO_API_KEY environment variable or pass to constructor.")
+            raise ValueError("API key required. Set PATENTSVIEW_API_KEY environment variable or pass to constructor.")
 
         self.headers = {
             "X-Api-Key": self.api_key,
@@ -101,15 +101,15 @@ class PatentSearchClient:
         """
         if fields is None:
             fields = [
-                "patent_number", "patent_title", "patent_date",
-                "patent_abstract", "assignee_organization",
-                "inventor_name", "cpc_subclass_id"
+                "patent_id", "patent_title", "patent_date",
+                "patent_abstract", "assignees",
+                "inventors"
             ]
 
         if sort is None:
             sort = [{"patent_date": "desc"}]
 
-        options = {"page": page, "per_page": min(per_page, 1000)}
+        options = {"size": 100}
 
         return self._request("patent", query, fields, sort, options)
 


### PR DESCRIPTION
Changes:

1. Add PatentsView API key for patent search API, the USPTO API key can't be used for patent search, need to apply API key from [PatentsView](https://patentsview.org/api-v01-information-page)
2. Revise sample snippet for syntax error, obsolete field name (search_patents)