### PR TITLE
Fix allowed-tools YAML frontmatter format across all skills

### DIFF
--- a/scientific-skills/citation-management/SKILL.md
+++ b/scientific-skills/citation-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: citation-management
 description: Comprehensive citation management for academic research. Search Google Scholar and PubMed for papers, extract accurate metadata, validate citations, and generate properly formatted BibTeX entries. This skill should be used when you need to find papers, verify citation information, convert DOIs to BibTeX, or ensure reference accuracy in scientific writing.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT License
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/clinical-decision-support/SKILL.md
+++ b/scientific-skills/clinical-decision-support/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clinical-decision-support
 description: Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT License
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/clinical-reports/SKILL.md
+++ b/scientific-skills/clinical-reports/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clinical-reports
 description: Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT License
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/hypothesis-generation/SKILL.md
+++ b/scientific-skills/hypothesis-generation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hypothesis-generation
 description: Structured hypothesis formulation from observations. Use when you have experimental observations or data and need to formulate testable hypotheses with predictions, propose mechanisms, and design experiments to test them. Follows scientific method framework. For open-ended ideation use scientific-brainstorming; for automated LLM-driven hypothesis testing on datasets use hypogenic.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/infographics/SKILL.md
+++ b/scientific-skills/infographics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infographics
 description: "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 ---
 
 # Infographics

--- a/scientific-skills/latex-posters/SKILL.md
+++ b/scientific-skills/latex-posters/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: latex-posters
 description: "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 ---
 
 # LaTeX Research Posters

--- a/scientific-skills/literature-review/SKILL.md
+++ b/scientific-skills/literature-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: literature-review
 description: Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/markdown-mermaid-writing/SKILL.md
+++ b/scientific-skills/markdown-mermaid-writing/SKILL.md
@@ -8,7 +8,7 @@ description: >
   source of truth, with clear pathways to downstream Python or AI-generated images.
   Includes full style guides (markdown + mermaid), 24 diagram type references, and
   9 document templates ready to use.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: Apache-2.0
 metadata:
   skill-author: Clayton Young / Superior Byte Works, LLC (@borealBytes)

--- a/scientific-skills/market-research-reports/SKILL.md
+++ b/scientific-skills/market-research-reports/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: market-research-reports
 description: Generate comprehensive market research reports (50+ pages) in the style of top consulting firms (McKinsey, BCG, Gartner). Features professional LaTeX formatting, extensive visual generation with scientific-schematics and generate-image, deep integration with research-lookup for data gathering, and multi-framework strategic analysis including Porter Five Forces, PESTLE, SWOT, TAM/SAM/SOM, and BCG Matrix.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/markitdown/SKILL.md
+++ b/scientific-skills/markitdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: markitdown
 description: Convert files and office documents to Markdown. Supports PDF, DOCX, PPTX, XLSX, images (with OCR), audio (with transcription), HTML, CSV, JSON, XML, ZIP, YouTube URLs, EPubs and more.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/paper-2-web/SKILL.md
+++ b/scientific-skills/paper-2-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-2-web
 description: This skill should be used when converting academic papers into promotional and presentation formats including interactive websites (Paper2Web), presentation videos (Paper2Video), and conference posters (Paper2Poster). Use this skill for tasks involving paper dissemination, conference preparation, creating explorable academic homepages, generating video abstracts, or producing print-ready posters from LaTeX or PDF sources.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: Unknown
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/peer-review/SKILL.md
+++ b/scientific-skills/peer-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peer-review
 description: Structured manuscript/grant review with checklist-based evaluation. Use when writing formal peer reviews with specific criteria methodology assessment, statistical validity, reporting standards compliance (CONSORT/STROBE), and constructive feedback. Best for actual review writing, manuscript revision. For evaluating claims/evidence quality use scientific-critical-thinking; for quantitative scoring frameworks use scholar-evaluation.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/pptx-posters/SKILL.md
+++ b/scientific-skills/pptx-posters/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pptx-posters
 description: Create research posters using HTML/CSS that can be exported to PDF or PPTX. Use this skill ONLY when the user explicitly requests PowerPoint/PPTX poster format. For standard research posters, use latex-posters instead. This skill provides modern web-based poster design with responsive layouts and easy visual integration.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/research-grants/SKILL.md
+++ b/scientific-skills/research-grants/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-grants
 description: Write competitive research proposals for NSF, NIH, DOE, DARPA, and Taiwan NSTC. Agency-specific formatting, review criteria, budget preparation, broader impacts, significance statements, innovation narratives, and compliance with submission requirements.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/research-lookup/SKILL.md
+++ b/scientific-skills/research-lookup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-lookup
 description: "Look up current research information using Perplexity's Sonar Pro Search or Sonar Reasoning Pro models through OpenRouter. Automatically selects the best model based on query complexity. Search academic papers, recent studies, technical documentation, and general research information with citations."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 ---
 
 # Research Information Lookup

--- a/scientific-skills/scientific-critical-thinking/SKILL.md
+++ b/scientific-skills/scientific-critical-thinking/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-critical-thinking
 description: Evaluate scientific claims and evidence quality. Use for assessing experimental design validity, identifying biases and confounders, applying evidence grading frameworks (GRADE, Cochrane Risk of Bias), or teaching critical analysis. Best for understanding evidence quality, identifying flaws. For formal peer review writing use peer-review.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/scientific-schematics/SKILL.md
+++ b/scientific-skills/scientific-schematics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-schematics
 description: Create publication-quality scientific diagrams using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Only regenerates if quality is below threshold for your document type. Specialized in neural network architectures, system diagrams, flowcharts, biological pathways, and complex scientific visualizations.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/scientific-slides/SKILL.md
+++ b/scientific-skills/scientific-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-slides
 description: Build slide decks and presentations for research talks. Use this for making PowerPoint slides, conference presentations, seminar talks, research presentations, thesis defense slides, or any scientific talk. Provides slide structure, design templates, timing guidance, and visual validation. Works with PowerPoint and LaTeX Beamer.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/scientific-writing/SKILL.md
+++ b/scientific-skills/scientific-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-writing
 description: Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process with (1) section outlines with key points using research-lookup then (2) convert to flowing prose. IMRAD structure, citations (APA/AMA/Vancouver), figures/tables, reporting guidelines (CONSORT/STROBE/PRISMA), for research papers and journal submissions.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/timesfm-forecasting/SKILL.md
+++ b/scientific-skills/timesfm-forecasting/SKILL.md
@@ -9,7 +9,7 @@ description: >
   intervals. Includes a preflight system checker script that MUST be run before first use
   to verify the machine can load the model. For classical statistical time series models
   (ARIMA, SARIMAX, VAR) use statsmodels; for time series classification/clustering use aeon.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: Apache-2.0 license
 metadata:
   skill-author: Clayton Young / Superior Byte Works, LLC (@borealBytes)

--- a/scientific-skills/treatment-plans/SKILL.md
+++ b/scientific-skills/treatment-plans/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treatment-plans
 description: Generate concise (3-4 page), focused medical treatment plans in LaTeX/PDF format for all clinical specialties. Supports general medical treatment, rehabilitation therapy, mental health care, chronic disease management, perioperative care, and pain management. Includes SMART goal frameworks, evidence-based interventions with minimal text citations, regulatory compliance (HIPAA), and professional formatting. Prioritizes brevity and clinical actionability.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.

--- a/scientific-skills/venue-templates/SKILL.md
+++ b/scientific-skills/venue-templates/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: venue-templates
 description: Access comprehensive LaTeX templates, formatting requirements, and submission guidelines for major scientific publication venues (Nature, Science, PLOS, IEEE, ACM), academic conferences (NeurIPS, ICML, CVPR, CHI), research posters, and grant proposals (NSF, NIH, DOE, DARPA). This skill should be used when preparing manuscripts for journal submission, conference papers, research posters, or grant proposals and need venue-specific formatting requirements and templates.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:
     skill-author: K-Dense Inc.


### PR DESCRIPTION
## Summary

Fixes #49

- Changed `allowed-tools` from YAML array format `[Read, Write, Edit, Bash]` to the spec-compliant space-delimited format `Read Write Edit Bash` across all 22 SKILL.md files
- The YAML array syntax was causing Claude Desktop to reject skills when importing as zip files; the space-delimited format follows the [SKILL.md specification](https://www.mdskills.ai/specs/skill-md)

## Test plan

- [ ] Verify skills can be imported into Claude Desktop app without errors
- [ ] Confirm allowed-tools are still recognized correctly by compatible agents