### PR TITLE
fix/rdkit-qed-module

### DIFF
--- a/scientific-skills/rdkit/scripts/molecular_properties.py
+++ b/scientific-skills/rdkit/scripts/molecular_properties.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 try:
     from rdkit import Chem
-    from rdkit.Chem import Descriptors, Lipinski
+    from rdkit.Chem import Descriptors, Lipinski, QED
 except ImportError:
     print("Error: RDKit not installed. Install with: conda install -c conda-forge rdkit")
     sys.exit(1)
@@ -68,7 +68,7 @@ def calculate_properties(mol):
         'BertzCT': Descriptors.BertzCT(mol),
 
         # Drug-likeness
-        'QED': Descriptors.qed(mol),
+        'QED': QED.qed(mol),
     }
 
     # Lipinski's Rule of Five


### PR DESCRIPTION
Use QED module for QED score calculation
ref: https://www.rdkit.org/docs/source/rdkit.Chem.QED.html#rdkit.Chem.QED.qed