### PR TITLE
feat: add materials-project skill (mp-api + pymatgen)

### DIFF
--- a/scientific-skills/materials-project/SKILL.md
+++ b/scientific-skills/materials-project/SKILL.md
@@ -1,0 +1,415 @@
+---
+name: materials-project
+description: Query the Materials Project database (150,000+ computed inorganic materials) using mp-api and pymatgen. Use for crystal structure retrieval, band gap and electronic structure analysis, phase diagram construction, formation energy calculations, thermodynamic stability screening, and high-throughput materials discovery workflows. Triggers on keywords like "materials project", "crystal structure", "band gap", "phase diagram", "formation energy", "mp-id", "pymatgen", "computational materials", "DFT", "convex hull", or any request to screen, search, or analyze inorganic solid-state materials at scale.
+allowed-tools: Read, Write, Edit, Bash
+license: MIT license
+metadata:
+  skill-author: Community Contributor
+---
+
+# Materials Project
+
+## What this is
+
+The Materials Project is a DOE-funded database of quantum-mechanical properties
+for over 150,000 inorganic materials, all computed with DFT. It has been running
+since 2011 and at this point it's basically the first stop for anyone doing
+computational materials work — battery research, solar cells, thermoelectrics,
+hard coatings, you name it. The data is free and the Python client (`mp-api`)
+is genuinely well-maintained.
+
+This skill wraps two things: `mp-api`, which is the official client for talking
+to the database, and `pymatgen` (Python Materials Genomics), which is the library
+that actually lets you do something useful with the structures and data you get
+back. The two are developed together and you really need both.
+
+## When to reach for this skill
+
+Any time the conversation involves:
+
+- Looking up a crystal structure, pulling a band gap, or grabbing formation
+  energies for a list of materials
+- Building a phase diagram and checking whether something sits on the convex hull
+- Screening thousands of materials by property ranges — band gap windows,
+  stability cutoffs, magnetic ordering, etc.
+- Starting a DFT calculation and needing a properly-relaxed input structure
+- Converting between structure file formats (CIF, POSCAR, XYZ, JSON)
+- Symmetry work — space groups, Wyckoff positions, primitive vs. conventional cells
+- Anything described as "high-throughput" or "computational materials screening"
+
+Keywords that should trigger this: "materials project", "crystal structure",
+"band gap", "phase diagram", "formation energy", "energy above hull", "pymatgen",
+"mp-api", "mp-id", "DFT", "convex hull", "inorganic material", "solid-state",
+"thermoelectric", "battery cathode", "solar absorber", "synthesizability".
+
+## Getting your API key
+
+You need an API key. It's completely free, just requires registration.
+
+Sign up at https://materialsproject.org, then go to your dashboard and hit
+"Generate API Key". You'll get a long alphanumeric string — treat it like a
+password, don't commit it to version control.
+
+The cleanest way to handle it is an environment variable:
+
+```bash
+export MP_API_KEY="your_api_key_here"
+```
+
+Put that in your `.bashrc` or `.zshrc` and forget about it. Once it's set,
+`MPRester()` picks it up automatically and you never have to pass it explicitly.
+
+If you'd rather configure it through pymatgen (writes to `~/.config/pymatgen/config.yaml`):
+
+```bash
+python -c "from pymatgen.core import SETTINGS; SETTINGS['PMG_MAPI_KEY'] = 'your_key'"
+```
+
+One thing worth knowing: the free tier is rate-limited to around 5 requests/second
+and 1,000 requests/hour. In practice this is fine for most workflows, but if
+you're looping over individual material IDs for a large list, you'll hit the wall.
+The fix is always to use a single `search()` call with `material_ids=[...]` rather
+than individual lookups — the API handles batching internally.
+
+## Installation
+
+```bash
+# the two things you actually need
+uv pip install mp-api pymatgen
+
+# visualization — add these if you're plotting phase diagrams or DOS
+uv pip install matplotlib plotly crystal-toolkit
+
+# if you're working in notebooks or doing ML feature generation
+uv pip install jupyter matminer
+```
+
+pymatgen requires Python 3.10 or newer. If you're on something older, upgrade
+before trying to debug mysterious import errors.
+
+## Core patterns
+
+### Searching by formula or chemical system
+
+The `summary` endpoint is where you'll spend most of your time. It has the
+broadest coverage and the fastest response times.
+
+```python
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    results = mpr.materials.summary.search(
+        formula="Fe2O3",
+        fields=["material_id", "formula_pretty", "energy_above_hull",
+                "band_gap", "is_stable"]
+    )
+    for r in results:
+        print(r.material_id, r.formula_pretty, r.energy_above_hull, r.band_gap)
+```
+
+Always pass `fields`. Without it, the API returns everything it knows about each
+material, which is slow and wastes bandwidth. Only request what you'll actually use.
+
+### Fetching a structure by MP ID
+
+```python
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    structure = mpr.get_structure_by_material_id("mp-1234")
+
+print(structure)
+print(f"Space group: {structure.get_space_group_info()}")
+print(f"Lattice: {structure.lattice}")
+
+# save it
+structure.to(filename="mp-1234.cif")       # CIF
+structure.to(filename="POSCAR")             # VASP input
+```
+
+The returned object is a pymatgen `Structure` — you get all pymatgen's analysis
+methods on it for free.
+
+### Screening by property range
+
+Pass a `(min, max)` tuple for any numeric field. Use `None` for an open-ended
+bound. This is how you do large-scale screening without looping:
+
+```python
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    candidates = mpr.materials.summary.search(
+        band_gap=(1.0, 2.0),
+        is_stable=True,
+        is_metal=False,
+        fields=["material_id", "formula_pretty", "band_gap",
+                "formation_energy_per_atom", "density"]
+    )
+
+print(f"Found {len(candidates)} candidates")
+for c in candidates[:10]:
+    print(f"{c.formula_pretty:15s}  Eg={c.band_gap:.2f} eV  "
+          f"Ef={c.formation_energy_per_atom:.3f} eV/atom")
+```
+
+### Phase diagrams
+
+This is one of the most powerful things the Materials Project enables. You pull
+all the entries for a chemical system and let pymatgen compute the convex hull:
+
+```python
+from mp_api.client import MPRester
+from pymatgen.analysis.phase_diagram import PhaseDiagram, PDPlotter
+
+with MPRester() as mpr:
+    entries = mpr.get_entries_in_chemsys(["Li", "Fe", "O"])
+
+pd = PhaseDiagram(entries)
+PDPlotter(pd).show()
+
+# check how stable a specific compound is
+with MPRester() as mpr:
+    entry = mpr.get_entry_by_material_id("mp-757979")
+
+ehull = pd.get_e_above_hull(entry)
+print(f"Energy above hull: {ehull:.3f} eV/atom")
+# < 0.025 eV/atom is generally considered synthesizable
+```
+
+### Electronic structure (DOS and band structure)
+
+```python
+from mp_api.client import MPRester
+from pymatgen.electronic_structure.plotter import DosPlotter, BSPlotter
+
+with MPRester() as mpr:
+    dos = mpr.get_dos_by_material_id("mp-2715")   # GaAs
+    bs  = mpr.get_bandstructure_by_material_id("mp-2715")
+
+dp = DosPlotter()
+dp.add_dos("Total DOS", dos)
+dp.get_plot(xlim=(-6, 6)).show()
+
+BSPlotter(bs).get_plot().show()
+
+print(f"Band gap: {bs.get_band_gap()['energy']:.3f} eV")
+print(f"Direct gap: {bs.get_band_gap()['direct']}")
+```
+
+### Symmetry analysis
+
+```python
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    structure = mpr.get_structure_by_material_id("mp-22862")  # TiO2 rutile
+
+sga = SpacegroupAnalyzer(structure)
+print(f"Space group: {sga.get_space_group_symbol()} ({sga.get_space_group_number()})")
+print(f"Crystal system: {sga.get_crystal_system()}")
+print(f"Point group: {sga.get_point_group_symbol()}")
+
+primitive    = sga.get_primitive_standard_structure()
+conventional = sga.get_conventional_standard_structure()
+```
+
+The default `symprec=0.1` Å works fine for MP structures. If you're analyzing
+slightly distorted structures from a relaxation that didn't fully converge, try
+bumping it to `0.3` before concluding the symmetry is broken.
+
+### Bulk screening into a DataFrame
+
+For anything involving more than ~20 materials, put it in a DataFrame:
+
+```python
+import pandas as pd
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    results = mpr.materials.summary.search(
+        chemsys="Li-*-O",
+        energy_above_hull=(0, 0.05),
+        fields=["material_id", "formula_pretty", "band_gap",
+                "formation_energy_per_atom", "energy_above_hull",
+                "theoretical", "nsites"]
+    )
+
+df = pd.DataFrame([{
+    "mp_id":     r.material_id,
+    "formula":   r.formula_pretty,
+    "Eg_eV":     r.band_gap,
+    "Ef_eV_at":  r.formation_energy_per_atom,
+    "Ehull":     r.energy_above_hull,
+    "theory_only": r.theoretical,
+    "n_sites":   r.nsites,
+} for r in results])
+
+df.sort_values("Ehull").to_csv("li_oxide_screen.csv", index=False)
+```
+
+### Elastic and mechanical properties
+
+Not every material in the database has elasticity data — the calculations are
+expensive. But for the ones that do:
+
+```python
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    docs = mpr.materials.elasticity.search(
+        material_ids=["mp-149"],   # Si
+        fields=["material_id", "bulk_modulus", "shear_modulus",
+                "universal_anisotropy", "elastic_tensor"]
+    )
+
+if docs:
+    e = docs[0]
+    print(f"Bulk modulus (Voigt): {e.bulk_modulus.voigt:.1f} GPa")
+    print(f"Shear modulus (Voigt): {e.shear_modulus.voigt:.1f} GPa")
+    print(f"Anisotropy: {e.universal_anisotropy:.4f}")
+```
+
+### Magnetic properties
+
+```python
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    results = mpr.materials.summary.search(
+        formula="Fe*O*",
+        ordering="FiM",   # FM, AFM, FiM, or NM
+        fields=["material_id", "formula_pretty", "total_magnetization",
+                "ordering", "band_gap"]
+    )
+
+for r in results:
+    print(f"{r.formula_pretty:15s}  μ={r.total_magnetization:.2f} μB  "
+          f"{r.ordering}  Eg={r.band_gap:.2f} eV")
+```
+
+### Preparing VASP input files
+
+```python
+from mp_api.client import MPRester
+from pymatgen.io.vasp.sets import MPRelaxSet
+from monty.serialization import dumpfn
+
+with MPRester() as mpr:
+    structure = mpr.get_structure_by_material_id("mp-804")  # LiFePO4
+
+# writes INCAR, KPOINTS, POSCAR (and POTCAR if your PSP library is configured)
+MPRelaxSet(structure).write_input("./vasp_inputs/")
+
+# also save a JSON copy for later
+dumpfn(structure, "LiFePO4.json")
+```
+
+If you get an error about POTCAR, add `potcar_spec=True` to `write_input()` —
+it writes a POTCAR.spec file listing the pseudopotentials without needing your
+local POTCAR library. You'd still need to assemble the actual POTCAR before
+submitting to a cluster.
+
+## API endpoints at a glance
+
+The `MPRester` organizes data into sub-clients. You access them as `mpr.<name>`:
+
+| Sub-client | What you get |
+|---|---|
+| `mpr.materials.summary` | The main one — formula, stability, band gap, magnetic ordering |
+| `mpr.materials.electronic_structure` | DOS and band structure objects |
+| `mpr.materials.elasticity` | Elastic tensor, bulk/shear moduli, Poisson ratio |
+| `mpr.materials.magnetism` | Magnetic ordering, site-resolved moments |
+| `mpr.materials.dielectric` | Dielectric tensor, refractive index |
+| `mpr.materials.piezoelectric` | Piezoelectric tensor and derived properties |
+| `mpr.materials.phonon` | Phonon band structure and DOS |
+| `mpr.materials.substrates` | Epitaxial substrate suggestions |
+| `mpr.materials.surface_properties` | Surface energies, work functions |
+| `mpr.materials.grain_boundaries` | Grain boundary energies |
+| `mpr.materials.bonds` | Chemical bonding graphs |
+| `mpr.materials.chemenv` | Chemical environment (coordination) analysis |
+| `mpr.materials.alloys` | Suggested alloy pairs from phase stability |
+| `mpr.materials.oxidation_states` | Predicted oxidation states |
+| `mpr.materials.thermo` | Thermodynamic entries for phase diagram work |
+| `mpr.materials.absorption` | Optical absorption spectra |
+| `mpr.molecules.summary` | Molecular properties (separate dataset) |
+
+To see every queryable field on an endpoint:
+
+```python
+with MPRester() as mpr:
+    print(mpr.materials.summary.available_fields)
+```
+
+## Key pymatgen objects
+
+| Class | Module | What it does |
+|---|---|---|
+| `Structure` | `pymatgen.core` | Periodic crystal structure — everything hangs off this |
+| `Composition` | `pymatgen.core` | Chemical formula with proper element arithmetic |
+| `Element`, `Species` | `pymatgen.core` | Element and oxidation-state representations |
+| `Lattice` | `pymatgen.core` | Bravais lattice with all crystallographic methods |
+| `SpacegroupAnalyzer` | `pymatgen.symmetry.analyzer` | Space group, point group, Wyckoff positions |
+| `PhaseDiagram` | `pymatgen.analysis.phase_diagram` | Convex hull from a list of entries |
+| `PDPlotter` | `pymatgen.analysis.phase_diagram` | 2D/3D phase diagram plots |
+| `DosPlotter` | `pymatgen.electronic_structure.plotter` | DOS visualization |
+| `BSPlotter` | `pymatgen.electronic_structure.plotter` | Band structure plots |
+| `MPRelaxSet` | `pymatgen.io.vasp.sets` | Standard MP-compatible VASP inputs |
+| `CifParser` | `pymatgen.io.cif` | Read/write CIF files |
+| `StructureMatcher` | `pymatgen.analysis.structure_matcher` | Compare structures for equivalence |
+| `BVAnalyzer` | `pymatgen.analysis.bond_valence` | Oxidation state assignment via bond valence |
+
+## Things that will trip you up
+
+**"API key not found" error** — You either forgot to set `MP_API_KEY` or the
+environment variable isn't being picked up by the current shell. Run
+`echo $MP_API_KEY` to confirm it's there. If empty, re-export it or pass
+the key directly as `MPRester("your_key")`.
+
+**Rate limit (HTTP 429)** — You're hitting the API in a tight loop. Switch to
+a single `search()` call with `material_ids=[list_of_ids]` instead of looping.
+If you genuinely need per-entry calls, add `time.sleep(0.25)` between them.
+
+**Empty results from a chemsys query** — The chemical system format is hyphen-separated
+elements, e.g. `"Li-Fe-O"`, not comma-separated. Also note that `chemsys` returns
+*all* sub-systems — so `"Li-Fe-O"` includes Li oxides, Fe oxides, and binary
+compounds in addition to ternaries. Use `nelements=3` to filter to strictly
+ternary if that's what you want.
+
+**Wrong MPRester import** — There are two. The old one is
+`from pymatgen.ext.matproj import MPRester` and it points at the deprecated v1 API.
+Always use `from mp_api.client import MPRester`. If your code was written before
+2022, this is probably the issue.
+
+**`MontyDecodeError`** — Usually a version mismatch between `mp-api` and `pymatgen`.
+Run `uv pip install --upgrade mp-api pymatgen` to sync them.
+
+**Missing POTCAR when writing VASP inputs** — `MPRelaxSet.write_input()` needs a
+local POTCAR library configured via `PMG_VASP_PSP_DIR`. If you're just prototyping
+or don't have the PAW files, pass `potcar_spec=True` and it'll write a spec file
+instead of complaining.
+
+**`theoretical=True` results mixed in** — The default search includes both
+experimentally observed compounds (from the ICSD) and purely theoretical ones.
+Set `theoretical=False` to restrict to compounds that have actually been made.
+This matters a lot for synthesizability assessments.
+
+## Works well alongside
+
+- **matplotlib / plotly** — for phase diagram figures, DOS plots, property scatter plots
+- **matminer** — for generating ML features from MP structures at scale
+- **deepchem** — materials ML models trained on MP data
+- **ase** (Atomic Simulation Environment) — `AseAtomsAdaptor` converts between
+  pymatgen `Structure` and ASE `Atoms` objects for MD or NEB workflows
+- **exploratory-data-analysis** skill — pandas + seaborn for screening large result sets
+- **molecular-dynamics** skill — use MP structures as starting geometries for AIMD
+
+## Further reading
+
+- `references/api_endpoints.md` — detailed field listings for every endpoint
+- `references/pymatgen_analysis.md` — deeper coverage of symmetry, phase diagrams,
+  electronic structure, and structure manipulation in pymatgen
+- `references/workflows.md` — complete worked examples for battery screening,
+  solar absorbers, thermoelectrics, defect calculations, and combining MP data
+  with local DFT results

--- a/scientific-skills/materials-project/references/api_endpoints.md
+++ b/scientific-skills/materials-project/references/api_endpoints.md
@@ -1,0 +1,306 @@
+# API Endpoints
+
+This covers the `mp-api` v2 client in enough depth to do real work with it.
+Most people only ever touch `mpr.materials.summary` — which is fine, it covers
+90% of use cases — but the specialized endpoints are worth knowing about when
+you need elasticity, phonons, or surface data.
+
+---
+
+## Setting up the client
+
+```python
+from mp_api.client import MPRester
+
+# If MP_API_KEY is set in your environment, this just works
+with MPRester() as mpr:
+    ...
+
+# Or pass the key directly — fine for scripts, bad for shared code
+with MPRester("your_api_key_here") as mpr:
+    ...
+```
+
+The `with` block isn't just convention — it closes the underlying HTTP session
+cleanly when you're done. If you're doing a lot of work in a notebook, you can
+keep the session open longer:
+
+```python
+mpr = MPRester()
+# ... lots of queries ...
+mpr.session.close()
+```
+
+But the context manager is cleaner and harder to forget.
+
+---
+
+## `mpr.materials.summary` — your first stop for everything
+
+The summary endpoint aggregates the most-used properties from all other
+endpoints into one place. If you're doing screening, this is usually all you need.
+
+### Fields worth knowing
+
+| Field | Type | Notes |
+|---|---|---|
+| `material_id` | str | The canonical MP identifier, e.g. `"mp-149"` |
+| `formula_pretty` | str | Reduced formula like `"Fe2O3"` |
+| `chemsys` | str | Hyphen-separated chemical system, e.g. `"Fe-O"` |
+| `nelements` | int | Number of distinct elements |
+| `nsites` | int | Number of sites in the primitive unit cell |
+| `volume` | float | Unit cell volume in Å³ |
+| `density` | float | Mass density in g/cm³ |
+| `density_atomic` | float | Number density in atoms/Å³ |
+| `crystal_system` | str | `"cubic"`, `"tetragonal"`, `"hexagonal"`, etc. |
+| `spacegroup_number` | int | International Tables number (1–230) |
+| `spacegroup_symbol` | str | Hermann–Mauguin symbol like `"Fm-3m"` |
+| `band_gap` | float | DFT band gap in eV; 0.0 for metals |
+| `is_gap_direct` | bool | Whether the gap is direct (same k-point for VBM and CBM) |
+| `is_metal` | bool | True when band_gap == 0 |
+| `formation_energy_per_atom` | float | DFT formation energy in eV/atom |
+| `energy_above_hull` | float | Distance above convex hull in eV/atom; 0 = on hull |
+| `is_stable` | bool | True when energy_above_hull == 0 |
+| `ordering` | str | Magnetic ground state: `"FM"`, `"AFM"`, `"FiM"`, `"NM"` |
+| `total_magnetization` | float | Total magnetic moment in μ_B per formula unit |
+| `total_magnetization_normalized_vol` | float | Magnetization per Å³ |
+| `num_magnetic_sites` | int | Count of sites with nonzero moment |
+| `theoretical` | bool | True if the structure has no ICSD match (not experimentally observed) |
+| `database_IDs` | dict | Cross-references to ICSD, COD, etc. |
+| `deprecated` | bool | Don't use deprecated entries — they've been superseded |
+
+### Range queries
+
+For any numeric field, pass a `(min, max)` tuple. Either side can be `None`
+for an open bound:
+
+```python
+with MPRester() as mpr:
+    results = mpr.materials.summary.search(
+        band_gap=(1.0, 2.0),          # 1.0 ≤ band_gap ≤ 2.0 eV
+        energy_above_hull=(0, 0.1),   # within 100 meV/atom of hull
+        nsites=(None, 30),            # up to 30 atoms in the cell
+        fields=["material_id", "formula_pretty", "band_gap",
+                "energy_above_hull"]
+    )
+```
+
+### `formula` vs `chemsys` — pick the right one
+
+These behave differently and the distinction matters:
+
+```python
+# formula: exact reduced stoichiometry, all polymorphs
+mpr.materials.summary.search(formula="LiFePO4")
+
+# chemsys: ALL materials containing exactly these elements
+# (and all sub-systems — so Li-Fe-P-O includes Li oxides, Fe phosphates, etc.)
+mpr.materials.summary.search(chemsys="Li-Fe-P-O")
+
+# wildcard: Li + any one other element + O
+mpr.materials.summary.search(chemsys="Li-*-O")
+```
+
+If you want strictly ternaries from a chemsys search, filter with `nelements=3`.
+
+### Check available fields at runtime
+
+The API evolves. If you're not sure what's queryable:
+
+```python
+with MPRester() as mpr:
+    print(mpr.materials.summary.available_fields)
+```
+
+---
+
+## `mpr.materials.thermo` — thermodynamic entries for phase diagrams
+
+This is what you use when you need `ComputedEntry` objects for phase diagram
+construction rather than just summary numbers.
+
+```python
+with MPRester() as mpr:
+    # Returns a list of ComputedEntry objects
+    entries = mpr.get_entries_in_chemsys(["Li", "Fe", "O"])
+```
+
+The convenience method `get_entries_in_chemsys()` is the cleanest way to get
+everything you need for a `PhaseDiagram`. The raw endpoint has more options:
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.thermo.search(
+        material_ids=["mp-19770", "mp-804"],
+        fields=["material_id", "thermo_type", "energy_per_atom",
+                "formation_energy_per_atom", "energy_above_hull"]
+    )
+```
+
+---
+
+## `mpr.materials.electronic_structure` — DOS and band structures
+
+For electronic structure you'll mostly use the convenience methods, which
+return proper pymatgen objects:
+
+```python
+with MPRester() as mpr:
+    dos = mpr.get_dos_by_material_id("mp-2715")    # returns CompleteDos
+    bs  = mpr.get_bandstructure_by_material_id("mp-2715")  # BandStructureSymmLine
+    bs_uniform = mpr.get_bandstructure_by_material_id(
+        "mp-2715", line_mode=False     # uniform k-mesh, for DOS consistency checks
+    )
+```
+
+Not all materials have electronic structure data computed — it's the more
+expensive calculations. If the call returns `None`, the data doesn't exist for
+that entry. Worth checking before your code assumes it got something back.
+
+---
+
+## `mpr.materials.elasticity` — mechanical properties
+
+Coverage is partial (elasticity is expensive to compute) but the data quality
+is good where it exists.
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.elasticity.search(
+        material_ids=["mp-149"],
+        fields=["material_id", "bulk_modulus", "shear_modulus",
+                "universal_anisotropy", "homogeneous_poisson",
+                "elastic_tensor"]
+    )
+
+if docs:
+    e = docs[0]
+    # bulk_modulus and shear_modulus have .voigt, .reuss, .vrh attributes
+    print(f"K_VRH = {e.bulk_modulus.vrh:.1f} GPa")
+    print(f"G_VRH = {e.shear_modulus.vrh:.1f} GPa")
+    print(f"Poisson = {e.homogeneous_poisson:.3f}")
+    print(f"Anisotropy index = {e.universal_anisotropy:.4f}")
+```
+
+The `elastic_tensor` field gives you the full 6×6 Voigt tensor in GPa if you
+need to do your own analysis beyond the derived quantities.
+
+---
+
+## `mpr.materials.magnetism` — magnetic properties
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.magnetism.search(
+        material_ids=["mp-19770"],
+        fields=["material_id", "ordering", "total_magnetization",
+                "magmoms", "exchange_symmetry"]
+    )
+```
+
+`magmoms` gives you site-resolved magnetic moments. `exchange_symmetry` is
+relevant for materials where the magnetic unit cell differs from the structural one.
+
+---
+
+## `mpr.materials.dielectric` — optical and dielectric response
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.dielectric.search(
+        material_ids=["mp-2715"],
+        fields=["material_id", "n", "e_total", "e_ionic", "e_electronic"]
+    )
+```
+
+`n` is the refractive index. `e_total` is the static dielectric tensor;
+`e_ionic` and `e_electronic` are the ionic and electronic contributions.
+These are directional properties (tensors), so you'll usually want to average
+the diagonal for an isotropic estimate.
+
+---
+
+## `mpr.materials.phonon` — lattice dynamics
+
+Phonon calculations are among the most computationally expensive in the database
+so coverage is limited, but it's growing.
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.phonon.search(
+        material_ids=["mp-149"],
+        fields=["material_id", "ph_dos", "ph_bs", "last_updated"]
+    )
+```
+
+Returns pymatgen `PhononDos` and `PhononBandStructureSymmLine` objects. Useful
+for checking dynamical stability (imaginary modes mean the structure is unstable)
+and computing thermodynamic quantities like entropy and heat capacity.
+
+---
+
+## `mpr.materials.surface_properties` — surface energies
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.surface_properties.search(
+        material_ids=["mp-149"],
+        fields=["material_id", "weighted_surface_energy",
+                "surfaces", "shape_factor"]
+    )
+```
+
+`weighted_surface_energy` is in J/m² and represents the Wulff-weighted average
+across all computed facets. `surfaces` is a list of documents, each with Miller
+indices, surface energy, and work function for that specific termination.
+
+---
+
+## `mpr.materials.oxidation_states` — valence prediction
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.oxidation_states.search(
+        formula="Fe2O3",
+        fields=["material_id", "possible_species",
+                "possible_valences", "method"]
+    )
+```
+
+Useful when you need to decorate a structure with oxidation states for
+bond valence analysis or preparing inputs for some DFT codes.
+
+---
+
+## Batch queries — the right way to do bulk lookups
+
+If you have a list of MP IDs and need properties for all of them, do it in
+one call:
+
+```python
+with MPRester() as mpr:
+    docs = mpr.materials.summary.search(
+        material_ids=["mp-149", "mp-804", "mp-22862", "mp-2715"],
+        fields=["material_id", "formula_pretty", "band_gap",
+                "formation_energy_per_atom"]
+    )
+```
+
+This is dramatically faster than calling `get_structure_by_material_id()` in a
+loop and won't hit rate limits on even moderately large lists (hundreds of IDs).
+
+---
+
+## Counting results before downloading
+
+Sometimes you just want to know how many entries match before committing to
+pulling all the data:
+
+```python
+with MPRester() as mpr:
+    count = mpr.materials.summary.count(formula="TiO2")
+    print(f"TiO2 polymorphs in the database: {count}")
+```
+
+Also handy for checking whether a query is narrowed down enough before
+running it for real.

--- a/scientific-skills/materials-project/references/pymatgen_analysis.md
+++ b/scientific-skills/materials-project/references/pymatgen_analysis.md
@@ -1,0 +1,342 @@
+# pymatgen Analysis
+
+pymatgen is a large library and most people only use a fraction of it. This
+covers the parts that come up most often when working with Materials Project data —
+structure handling, symmetry, phase diagrams, electronic structure, and getting
+data into formats other tools understand.
+
+All examples assume you already have a `Structure` object, either from `mp-api`
+or loaded from a file.
+
+---
+
+## Reading and writing structures
+
+pymatgen can figure out the file format from the extension in most cases:
+
+```python
+from pymatgen.core import Structure
+
+# from file — works for CIF, POSCAR/CONTCAR, XYZ, JSON, and others
+structure = Structure.from_file("structure.cif")
+structure = Structure.from_file("POSCAR")
+
+# from a JSON saved with monty
+from monty.serialization import loadfn
+structure = loadfn("structure.json")
+
+# from an ASE Atoms object (useful if you're coming from ASE or GPAW)
+from pymatgen.io.ase import AseAtomsAdaptor
+structure = AseAtomsAdaptor.get_structure(ase_atoms)
+```
+
+Writing is similarly straightforward:
+
+```python
+structure.to(filename="output.cif")
+structure.to(filename="POSCAR")
+structure.to(filename="output.xyz")   # non-periodic, mostly for visualization
+
+# monty JSON — fully roundtrip serializable
+from monty.serialization import dumpfn
+dumpfn(structure, "structure.json")
+
+# convert to ASE for downstream MD or NEB calculations
+from pymatgen.io.ase import AseAtomsAdaptor
+atoms = AseAtomsAdaptor.get_atoms(structure)
+```
+
+---
+
+## SpacegroupAnalyzer — symmetry work
+
+The workhorse for anything symmetry-related. It wraps spglib under the hood.
+
+```python
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+sga = SpacegroupAnalyzer(structure, symprec=0.1)
+
+sga.get_space_group_number()      # e.g. 225
+sga.get_space_group_symbol()      # e.g. "Fm-3m"
+sga.get_point_group_symbol()      # e.g. "m-3m"
+sga.get_crystal_system()          # "cubic", "tetragonal", etc.
+sga.get_lattice_type()            # similar, but returns the Bravais lattice type
+sga.get_hall()                    # Hall symbol
+
+primitive    = sga.get_primitive_standard_structure()
+conventional = sga.get_conventional_standard_structure()
+refined      = sga.get_refined_structure()
+
+sym_ops     = sga.get_symmetry_operations()      # list of SymmOp objects
+sym_dataset = sga.get_symmetry_dataset()         # raw spglib output dict
+sym_struct  = sga.get_symmetrized_structure()    # SymmetrizedStructure with Wyckoff labels
+```
+
+A note on `symprec`: the default of `0.1` Å is calibrated for well-converged
+DFT structures from the Materials Project. If you're working with a structure
+from a less tightly converged relaxation, or something with thermal expansion
+baked in, you might need `0.3` or even `0.5` to get sensible results. Going too
+high will spuriously merge distinct sites.
+
+---
+
+## PhaseDiagram — thermodynamic stability
+
+This is one of the more powerful things you can do with MP data. You pull all
+the computed entries for a chemical system and pymatgen does the convex hull
+construction.
+
+```python
+from mp_api.client import MPRester
+from pymatgen.analysis.phase_diagram import PhaseDiagram, PDPlotter
+
+with MPRester() as mpr:
+    entries = mpr.get_entries_in_chemsys(["Li", "Fe", "O"])
+
+pd_obj = PhaseDiagram(entries)
+
+# key methods
+pd_obj.stable_entries                          # set of entries on the hull
+pd_obj.unstable_entries                        # everything else
+pd_obj.get_e_above_hull(entry)                 # float, eV/atom
+pd_obj.get_decomposition(composition)          # {entry: fraction} dict
+pd_obj.get_equilibrium_reaction_energy(entry)  # float
+pd_obj.get_hull_energy(composition)            # hull energy at that composition
+pd_obj.get_form_energy(entry)                  # formation energy relative to references
+```
+
+As a rough guide: entries within ~25 meV/atom of the hull are generally
+considered synthesizable. Between 25 and 100 meV/atom is a gray zone where
+metastable phases are sometimes accessible. Above 100 meV/atom is usually
+unstable in practice, though there are exceptions (some kinetically trapped phases
+persist because the decomposition barrier is high).
+
+Plotting:
+
+```python
+plotter = PDPlotter(pd_obj, backend="matplotlib")
+plotter.show()
+plotter.get_plot(show_unstable=0.05).savefig("phase_diagram.png", dpi=300)
+# show_unstable=0.05 includes entries within 50 meV/atom of the hull
+```
+
+For open-system thermodynamics (e.g. oxygen partial pressure effects in
+oxide systems), use `GrandPotentialPhaseDiagram`:
+
+```python
+from pymatgen.analysis.phase_diagram import GrandPotentialPhaseDiagram
+from pymatgen.core import Element
+
+# fix the oxygen chemical potential (units: eV per O atom)
+# -5.0 eV is roughly reducing; -1.0 eV is strongly oxidizing
+gppd = GrandPotentialPhaseDiagram(entries, {Element("O"): -5.0})
+```
+
+---
+
+## StructureMatcher — comparing structures
+
+Useful for deduplication, finding equivalent polymorphs, and checking
+whether your DFT-relaxed structure drifted into a different phase.
+
+```python
+from pymatgen.analysis.structure_matcher import StructureMatcher
+
+sm = StructureMatcher(
+    ltol=0.2,             # fractional tolerance on lattice lengths
+    stol=0.3,             # site tolerance as fraction of average nearest-neighbor distance
+    angle_tol=5,          # tolerance on lattice angles (degrees)
+    primitive_cell=True,  # reduce to primitive cell before comparing
+    scale=True,           # allow volume scaling
+    attempt_supercell=False
+)
+
+sm.fit(s1, s2)                          # True if structures are equivalent
+sm.group_structures(list_of_structures)  # returns list of equivalent groups
+sm.get_mapping(s1, s2)                  # atom-to-atom mapping, or None
+sm.find_indexes(s1, [s2, s3, s4])       # index of the best match in the list
+```
+
+The defaults are reasonable for comparing MP structures to each other. If you're
+comparing against something from experiment (where the cell may not be optimally
+converged), loosen `ltol` and `angle_tol` somewhat.
+
+---
+
+## BVAnalyzer — oxidation state assignment via bond valence
+
+Quick and reasonably reliable for most ionic materials:
+
+```python
+from pymatgen.analysis.bond_valence import BVAnalyzer
+
+bva = BVAnalyzer()
+
+# returns a copy of the structure decorated with oxidation states
+structure_with_oxi = bva.get_oxi_state_decorated_structure(structure)
+
+# or just the list of valences
+valences = bva.get_valences(structure)   # list of floats, one per site
+```
+
+This can fail on unusual compounds or materials with mixed valency. In those
+cases `get_valences()` raises a `ValueError` — worth catching if you're running
+this in bulk.
+
+---
+
+## DosPlotter and BSPlotter — electronic structure visualization
+
+```python
+from mp_api.client import MPRester
+from pymatgen.electronic_structure.plotter import DosPlotter, BSPlotter
+
+with MPRester() as mpr:
+    dos = mpr.get_dos_by_material_id("mp-2715")
+    bs  = mpr.get_bandstructure_by_material_id("mp-2715")
+
+# DOS — add total and element-projected contributions
+dp = DosPlotter()
+dp.add_dos("Total", dos)
+dp.add_dos_dict(dos.get_element_dos())    # element-projected
+dp.add_dos_dict(dos.get_spd_dos())        # s/p/d orbital projected
+plt = dp.get_plot(xlim=(-6, 6), ylim=(-5, 20))
+plt.savefig("dos.png", dpi=300)
+
+# band structure
+bp = BSPlotter(bs)
+bp.get_plot(zero_to_efermi=True, vbm_cbm_marker=True).show()
+bp.save_plot("bandstructure.png")
+
+# extracting numbers you actually need
+bg = bs.get_band_gap()
+print(f"Gap: {bg['energy']:.3f} eV")
+print(f"Direct: {bg['direct']}")
+print(f"Transition: {bg['transition']}")   # e.g. "Γ→X" for indirect gap
+
+vbm = bs.get_vbm()   # dict with 'energy', 'kpoint', 'band_index'
+cbm = bs.get_cbm()
+print(f"VBM at {vbm['kpoint'].label}, {vbm['energy']:.3f} eV")
+print(f"CBM at {cbm['kpoint'].label}, {cbm['energy']:.3f} eV")
+```
+
+---
+
+## VASP input generation
+
+pymatgen has input sets that encode the standard MP calculation parameters —
+same ones used to build the database. This is helpful for making calculations
+that are directly comparable to MP data.
+
+```python
+from pymatgen.io.vasp.sets import (
+    MPRelaxSet,        # standard structure relaxation
+    MPStaticSet,       # single-point energy / charge density
+    MPNonSCFSet,       # non-self-consistent (DOS and band structure)
+    MPMetalRelaxSet,   # uses denser k-mesh and smearing for metals
+    MPScanRelaxSet     # SCAN meta-GGA functional
+)
+
+relax = MPRelaxSet(structure, user_incar_settings={"EDIFF": 1e-6})
+relax.write_input("./vasp_relax/")
+
+static = MPStaticSet(structure)
+static.write_input("./vasp_static/")
+
+# non-SCF for band structure, using the charge density from a prior static run
+nscf = MPNonSCFSet.from_prev_calc(prev_calc_dir="./vasp_static/", mode="line")
+nscf.write_input("./vasp_nscf/")
+```
+
+The `write_input()` method tries to write a POTCAR and will raise an error if
+`PMG_VASP_PSP_DIR` isn't configured. Workaround:
+
+```python
+relax.write_input("./vasp_relax/", potcar_spec=True)
+# writes POTCAR.spec instead — you assemble the real POTCAR separately
+```
+
+---
+
+## Composition — formula arithmetic
+
+`Composition` lets you work with chemical formulas as objects rather than strings,
+which is useful when building phase diagrams or comparing compositions:
+
+```python
+from pymatgen.core import Composition
+
+c = Composition("Li3PO4")
+
+c.reduced_formula                # "Li3PO4"
+c.hill_formula                   # "Li3O4P" (carbon-first, then alphabetical)
+c.formula                        # "Li3 P1 O4"
+c.num_atoms                      # 8.0
+c.weight                         # molecular weight in g/mol
+c.get_atomic_fraction("O")       # 0.5
+c.elements                       # [Element Li, Element P, Element O]
+c.chemical_system                # "Li-O-P"
+
+# element fractions
+for el, frac in c.items():
+    print(el, frac)
+```
+
+---
+
+## AseAtomsAdaptor — bridge to ASE
+
+If you need to use an ASE calculator (EMT, GPAW, MACE, etc.) with a structure
+from pymatgen:
+
+```python
+from pymatgen.io.ase import AseAtomsAdaptor
+
+# pymatgen → ASE
+atoms = AseAtomsAdaptor.get_atoms(structure)
+
+# ASE → pymatgen
+structure = AseAtomsAdaptor.get_structure(atoms)
+```
+
+This is a lossless roundtrip for the basic structural data (positions, cell,
+species). Some information like site properties and oxidation states may not
+survive depending on the ASE calculator's output format.
+
+---
+
+## matminer — ML feature generation from MP structures
+
+`matminer` is a separate package (not part of pymatgen) but is commonly used
+alongside it for building ML models on materials data:
+
+```bash
+uv pip install matminer
+```
+
+```python
+from matminer.featurizers.structure import SiteStatsFingerprint
+from matminer.featurizers.site import CrystalNNFingerprint
+import pandas as pd
+
+# Build a structural fingerprint featurizer
+ssf = SiteStatsFingerprint(CrystalNNFingerprint.from_preset("ops"))
+ssf.fit([structure])
+features = ssf.featurize(structure)   # numpy array of descriptors
+
+# Featurize a whole DataFrame of MP results efficiently
+df = pd.DataFrame([{
+    "structure": mpr.get_structure_by_material_id(r.material_id),
+    "band_gap":  r.band_gap,
+    "mp_id":     r.material_id,
+} for r in results])
+
+df = ssf.featurize_dataframe(df, "structure", ignore_errors=True)
+# ignore_errors=True skips structures that fail featurization
+# rather than crashing your whole batch
+```
+
+matminer has dozens of featurizers beyond `SiteStatsFingerprint`. The
+[matminer documentation](https://hackingmaterials.lbl.gov/matminer/) has a
+full catalog sorted by whether they operate on structures, compositions, or sites.

--- a/scientific-skills/materials-project/references/workflows.md
+++ b/scientific-skills/materials-project/references/workflows.md
@@ -1,0 +1,411 @@
+# Workflows
+
+Complete worked examples for common materials research tasks. Each one is
+self-contained and meant to be a starting point you can adapt rather than
+copy-paste verbatim.
+
+---
+
+## Battery cathode screening
+
+The goal here is to find thermodynamically stable Li-transition-metal oxides
+that might work as cathode materials. We screen a few TM chemistries at once and
+rank by stability and band gap (you want the cathode to be semiconducting, not
+metallic, so Li ions can intercalate without short-circuiting).
+
+```python
+import pandas as pd
+import matplotlib.pyplot as plt
+from mp_api.client import MPRester
+
+transition_metals = ["Mn", "Co", "Ni", "Fe"]
+all_candidates = []
+
+with MPRester() as mpr:
+    for tm in transition_metals:
+        results = mpr.materials.summary.search(
+            chemsys=f"Li-{tm}-O",
+            energy_above_hull=(0, 0.05),   # stable + near-stable
+            fields=["material_id", "formula_pretty", "band_gap",
+                    "formation_energy_per_atom", "energy_above_hull",
+                    "nsites", "volume", "density"]
+        )
+        for r in results:
+            all_candidates.append({
+                "mp_id":     r.material_id,
+                "formula":   r.formula_pretty,
+                "tm":        tm,
+                "Eg_eV":     r.band_gap,
+                "Ef_eV_at":  r.formation_energy_per_atom,
+                "Ehull_eV_at": r.energy_above_hull,
+                "nsites":    r.nsites,
+                "density":   r.density,
+            })
+
+df = pd.DataFrame(all_candidates)
+
+# exclude metals — a metallic cathode short-circuits the cell
+df = df[df["Eg_eV"] > 0.1]
+df = df.sort_values("Ehull_eV_at")
+
+print(f"Candidates after filtering: {len(df)}")
+print(df.head(20).to_string(index=False))
+
+# quick scatter to see the landscape
+fig, ax = plt.subplots(figsize=(8, 5))
+for tm, group in df.groupby("tm"):
+    ax.scatter(group["Eg_eV"], group["Ef_eV_at"], label=tm, alpha=0.7, s=40)
+ax.set_xlabel("Band gap (eV)")
+ax.set_ylabel("Formation energy (eV/atom)")
+ax.legend(title="TM")
+ax.set_title("Li-TM-O cathode candidates")
+plt.tight_layout()
+plt.savefig("cathode_screening.png", dpi=300)
+```
+
+---
+
+## Solar absorber search
+
+Direct-gap semiconductors in the 1.0–1.8 eV range are optimal for single-junction
+solar cells by the Shockley–Queisser limit. Si sits at 1.1 eV (indirect, so less
+than ideal), GaAs at 1.4 eV (direct, near-perfect). The question is what else is
+out there.
+
+```python
+import pandas as pd
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    results = mpr.materials.summary.search(
+        band_gap=(1.0, 1.8),
+        is_stable=True,
+        is_metal=False,
+        is_gap_direct=True,          # thin-film absorbers need direct gaps
+        nelements=(2, 4),            # keep it synthesizable
+        fields=["material_id", "formula_pretty", "band_gap",
+                "formation_energy_per_atom", "nelements",
+                "nsites", "theoretical", "crystal_system", "density"]
+    )
+
+df = pd.DataFrame([{
+    "mp_id":       r.material_id,
+    "formula":     r.formula_pretty,
+    "Eg_eV":       round(r.band_gap, 3),
+    "Ef_eV_at":    round(r.formation_energy_per_atom, 3),
+    "n_elem":      r.nelements,
+    "n_sites":     r.nsites,
+    "theory_only": r.theoretical,
+    "crystal":     r.crystal_system,
+    "density":     round(r.density, 2),
+} for r in results])
+
+# prioritize compounds that have actually been made
+exp_only = df[~df["theory_only"]].sort_values("Eg_eV")
+print(f"Experimentally known candidates: {len(exp_only)}")
+print(exp_only.to_string(index=False))
+
+df.to_csv("solar_absorber_candidates.csv", index=False)
+```
+
+GaAs (mp-2715) and CdTe (mp-406) should both show up here, which is a reasonable
+sanity check that the query is working.
+
+---
+
+## Phase diagram and stability assessment
+
+This is the standard way to figure out whether a composition is thermodynamically
+stable and what it would decompose into if it's not.
+
+```python
+from mp_api.client import MPRester
+from pymatgen.analysis.phase_diagram import PhaseDiagram, PDPlotter
+
+# download everything in the Li-Mn-O system
+with MPRester() as mpr:
+    entries = mpr.get_entries_in_chemsys(["Li", "Mn", "O"])
+
+print(f"Loaded {len(entries)} entries")
+
+pd_obj = PhaseDiagram(entries)
+
+# check a specific entry
+with MPRester() as mpr:
+    target = mpr.get_entry_by_material_id("mp-757979")   # LiMnO2
+
+e_hull = pd_obj.get_e_above_hull(target)
+decomp  = pd_obj.get_decomposition(target.composition)
+
+print(f"\nLiMnO2 — energy above hull: {e_hull:.4f} eV/atom")
+
+if e_hull < 0.025:
+    print("Within 25 meV/atom — likely synthesizable")
+elif e_hull < 0.1:
+    print("Metastable range — might be accessible with the right synthesis")
+else:
+    print("Probably unstable. Predicted to decompose into:")
+    for entry, frac in decomp.items():
+        print(f"  {entry.composition.reduced_formula}: {frac:.3f}")
+
+# save a plot
+plotter = PDPlotter(pd_obj)
+plotter.get_plot(show_unstable=0.05).savefig("LiMnO_phase_diagram.png", dpi=300)
+```
+
+---
+
+## Electronic structure analysis for a set of materials
+
+When you need band gaps, VBM/CBM positions, and DOS plots for a batch of materials,
+here's a pattern that collects the numbers into a summary DataFrame while also
+saving the individual figures:
+
+```python
+import pandas as pd
+import matplotlib.pyplot as plt
+from mp_api.client import MPRester
+from pymatgen.electronic_structure.plotter import DosPlotter, BSPlotter
+
+mp_ids = ["mp-149", "mp-2715", "mp-22862", "mp-804"]
+labels = ["Si", "GaAs", "TiO2-rutile", "LiFePO4"]
+
+records = []
+
+with MPRester() as mpr:
+    for mp_id, label in zip(mp_ids, labels):
+        bs  = mpr.get_bandstructure_by_material_id(mp_id)
+        dos = mpr.get_dos_by_material_id(mp_id)
+
+        # can be None if the calculation doesn't exist for that entry
+        if bs is None or dos is None:
+            print(f"Skipping {label} — electronic structure not available")
+            continue
+
+        bg  = bs.get_band_gap()
+        vbm = bs.get_vbm()
+        cbm = bs.get_cbm()
+
+        records.append({
+            "material":  label,
+            "mp_id":     mp_id,
+            "Eg_eV":     round(bg["energy"], 3),
+            "direct":    bg["direct"],
+            "transition": bg["transition"],
+            "VBM_eV":    round(vbm["energy"], 3),
+            "CBM_eV":    round(cbm["energy"], 3),
+        })
+
+        # DOS figure
+        dp = DosPlotter()
+        dp.add_dos("Total", dos)
+        dp.add_dos_dict(dos.get_element_dos())
+        dp.get_plot(xlim=(-6, 6)).savefig(f"dos_{label}.png", dpi=150)
+        plt.close()
+
+        # band structure figure
+        bp = BSPlotter(bs)
+        bp.get_plot(zero_to_efermi=True, vbm_cbm_marker=True).savefig(
+            f"bs_{label}.png", dpi=150)
+        plt.close()
+
+df = pd.DataFrame(records)
+print(df.to_string(index=False))
+df.to_csv("electronic_structure_summary.csv", index=False)
+```
+
+---
+
+## Thermoelectric material screening
+
+Good thermoelectrics need a narrow band gap (for sufficient carrier concentration),
+a complex crystal structure (for low lattice thermal conductivity), and decent
+thermodynamic stability. This query gets you a starting pool to work from:
+
+```python
+import pandas as pd
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    results = mpr.materials.summary.search(
+        band_gap=(0.05, 1.5),
+        energy_above_hull=(0, 0.05),
+        is_metal=False,
+        nsites=(4, 50),        # complex unit cells tend to scatter phonons more
+        nelements=(2, 5),
+        fields=["material_id", "formula_pretty", "band_gap",
+                "formation_energy_per_atom", "energy_above_hull",
+                "nsites", "nelements", "density", "crystal_system",
+                "spacegroup_number"]
+    )
+
+df = pd.DataFrame([{
+    "mp_id":      r.material_id,
+    "formula":    r.formula_pretty,
+    "Eg_eV":      round(r.band_gap, 3),
+    "Ef_eV_at":   round(r.formation_energy_per_atom, 3),
+    "Ehull_eV_at": round(r.energy_above_hull, 4),
+    "n_sites":    r.nsites,
+    "n_elem":     r.nelements,
+    "density":    round(r.density, 2),
+    "crystal":    r.crystal_system,
+    "spg":        r.spacegroup_number,
+} for r in results])
+
+# sort by unit cell complexity as a rough proxy for low κ_lattice
+df = df.sort_values("n_sites", ascending=False)
+print(f"Candidates: {len(df)}")
+print(df.head(25).to_string(index=False))
+df.to_csv("thermoelectric_candidates.csv", index=False)
+```
+
+Known good thermoelectrics like Bi₂Te₃ and PbTe should appear. If they don't,
+your `band_gap` or `nsites` range might be cutting them out.
+
+---
+
+## Supercell and defect preparation
+
+A common pre-step before defect calculations or MD simulations:
+
+```python
+from mp_api.client import MPRester
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+with MPRester() as mpr:
+    structure = mpr.get_structure_by_material_id("mp-149")   # Si
+
+# always use the conventional cell for supercell expansions
+# the primitive cell produces lopsided supercells
+sga = SpacegroupAnalyzer(structure)
+conv = sga.get_conventional_standard_structure()
+print(f"Conventional: {conv.formula}, {len(conv)} sites")
+
+# 2×2×2 supercell — 64 atoms for Si
+supercell = conv.copy()
+supercell.make_supercell([[2, 0, 0], [0, 2, 0], [0, 0, 2]])
+print(f"Supercell: {supercell.formula}, {len(supercell)} sites")
+
+# vacancy at site 0
+vacancy = supercell.copy()
+vacancy.remove_sites([0])
+vacancy.to(filename="POSCAR_Si_vacancy")
+
+# substitutional defect: replace site 0 with Ge
+sub = supercell.copy()
+sub[0] = "Ge"
+print(f"Ge substitution: {sub.formula}")
+sub.to(filename="POSCAR_Ge_sub")
+```
+
+One thing that catches people: `make_supercell()` modifies the structure in
+place. The `copy()` calls above are important — without them you'd be building
+on top of a structure you've already modified.
+
+---
+
+## Polymorph analysis
+
+How many distinct crystal structures exist for a given composition, and which
+are structurally equivalent (e.g. the same phase submitted to the database
+twice)?
+
+```python
+from mp_api.client import MPRester
+from pymatgen.analysis.structure_matcher import StructureMatcher
+
+formula = "TiO2"
+
+with MPRester() as mpr:
+    results = mpr.materials.summary.search(
+        formula=formula,
+        fields=["material_id", "formula_pretty", "energy_above_hull",
+                "spacegroup_symbol", "band_gap"]
+    )
+    structures = {
+        r.material_id: mpr.get_structure_by_material_id(r.material_id)
+        for r in results
+    }
+
+# print the landscape first
+for r in sorted(results, key=lambda x: x.energy_above_hull):
+    print(f"  {r.material_id:12s}  {r.spacegroup_symbol:10s}  "
+          f"Ehull={r.energy_above_hull:.4f} eV/at  Eg={r.band_gap:.2f} eV")
+
+# group into structurally equivalent sets
+sm = StructureMatcher()
+ids = list(structures.keys())
+already_seen = set()
+groups = []
+
+for id1 in ids:
+    if id1 in already_seen:
+        continue
+    group = [id1]
+    for id2 in ids:
+        if id2 != id1 and id2 not in already_seen:
+            if sm.fit(structures[id1], structures[id2]):
+                group.append(id2)
+                already_seen.add(id2)
+    already_seen.add(id1)
+    groups.append(group)
+
+print(f"\n{len(groups)} structurally distinct {formula} polymorphs:")
+for i, g in enumerate(groups):
+    print(f"  Group {i+1}: {', '.join(g)}")
+```
+
+Rutile, anatase, and brookite are the three well-known TiO2 polymorphs —
+they should all show up as separate groups.
+
+---
+
+## Using MP data alongside local DFT calculations
+
+This is what you do when you've run your own VASP calculation and want to
+know where your material sits on the phase diagram:
+
+```python
+from mp_api.client import MPRester
+from pymatgen.analysis.phase_diagram import PhaseDiagram
+from pymatgen.entries.computed_entries import ComputedEntry
+from pymatgen.core import Composition
+
+# your local result — total DFT energy and composition
+my_formula   = "Li2MnO3"
+my_energy_per_atom = -6.312   # replace with your actual value (eV/atom)
+my_comp      = Composition(my_formula)
+my_entry     = ComputedEntry(
+    composition=my_comp,
+    energy=my_energy_per_atom * my_comp.num_atoms,
+    entry_id="local-calc"
+)
+
+# download MP reference entries for the same chemical system
+elements = [str(el) for el in my_comp.elements]
+with MPRester() as mpr:
+    mp_entries = mpr.get_entries_in_chemsys(elements)
+
+# build the phase diagram including your entry
+all_entries = mp_entries + [my_entry]
+pd_obj      = PhaseDiagram(all_entries)
+
+e_hull = pd_obj.get_e_above_hull(my_entry)
+decomp = pd_obj.get_decomposition(my_entry.composition)
+
+print(f"{my_formula}: {e_hull:.4f} eV/atom above hull")
+
+if e_hull < 0.025:
+    print("Likely stable — sits on or very near the convex hull")
+else:
+    print("Predicted to decompose into:")
+    for entry, frac in decomp.items():
+        print(f"  {entry.composition.reduced_formula}: {frac:.3f}")
+```
+
+One caveat worth knowing: mixing your own DFT energies with MP energies only
+makes sense if you used compatible settings (same functional, pseudopotentials,
+k-mesh density, etc.). MP uses PBE with specific VASP settings — if your
+calculation used a different setup, the energy comparisons won't be meaningful.
+The `MaterialsProjectCompatibility` energy correction scheme exists for
+exactly this reason if you need to handle corrections properly.


### PR DESCRIPTION
What gap does this fill?
Computational materials science is currently not represented in K-Dense skills. This adds support for materials data access and analysis.

Who uses this?
Researchers and engineers in battery, solar, and semiconductor domains who rely on Materials Project data.

What does this enable?
- Query 150k+ materials using Materials Project API
- Retrieve properties like band gap, structure, composition
- Enable phase diagram analysis and materials exploration workflows