### PR TITLE
fix: resolve conflicting manifests error by setting strict: true

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "scientific-skills",
       "description": "Collection of scientific skills",
       "source": "./",
-      "strict": false,
+      "strict": true,
       "skills": [
         "./scientific-skills/adaptyv",
         "./scientific-skills/aeon",


### PR DESCRIPTION
## What changed

Set `strict: true` in `.claude-plugin/marketplace.json` for the `scientific-skills` plugin entry.

## Why

When loading the plugin, users encountered the following error:

```
Plugin scientific-skills has conflicting manifests: both plugin.json and marketplace entry
specify components. Set strict: true in marketplace entry or remove component specs from
one location.
```

Both `plugin.json` and the marketplace entry in `marketplace.json` had identical `skills` arrays defined, causing the plugin loader to detect a conflict and refuse to load.

## Fix

Setting `strict: true` in the marketplace entry tells the plugin loader to treat `plugin.json` as the authoritative source for component definitions, resolving the conflict without removing any functionality.

## Reviewer notes

- No functional change — same skills are loaded, just from `plugin.json` as the single source of truth
- The `skills` array in `marketplace.json` remains intact for reference but is now ignored by the loader