### PR TITLE
Add missing research-grants reference guides

### DIFF
--- a/scientific-skills/research-grants/SKILL.md
+++ b/scientific-skills/research-grants/SKILL.md
@@ -433,6 +433,8 @@ Demonstrate that the project is well-planned and achievable within the proposed 
 - Phase-based structure with exit criteria
 - Demonstration and transition planning
 
+For detailed milestone and schedule guidance, refer to `references/timeline_planning.md`.
+
 
 ### 9. Team Qualifications and Collaboration
 
@@ -515,6 +517,8 @@ Develop realistic budgets that align with the proposed work and agency guideline
 - Justify travel (conferences, collaborations)
 - Explain consultant roles and rates
 - Show how budget aligns with timeline
+
+For detailed budget strategy, refer to `references/budget_preparation.md`.
 
 
 ## Review Criteria by Agency
@@ -600,6 +604,7 @@ Varies by program office, but generally includes:
 4. **Value (價值)**: Academic contribution and societal/industrial impact.
 
 For detailed review criteria, refer to `references/nstc_guidelines.md`.
+For a cross-agency comparison, refer to `references/review_criteria.md`.
 - **What if you succeed?** (Impact if the research works)
 - **What if you're right?** (Implications of your hypothesis)
 - **Who cares?** (Why it matters for national security)
@@ -920,6 +925,9 @@ This skill includes comprehensive reference files covering specific aspects of g
 - `references/broader_impacts.md`: Strategies for compelling broader impacts statements
 - `references/specific_aims_guide.md`: Writing effective specific aims pages
 - `references/nstc_guidelines.md`: NSTC-specific guidelines and review criteria
+- `references/budget_preparation.md`: Building realistic budgets and budget justifications
+- `references/review_criteria.md`: Cross-agency comparison of how proposals are evaluated
+- `references/timeline_planning.md`: Designing milestones, work packages, and realistic project schedules
 
 Load these references as needed when working on specific aspects of grant writing.
 

--- a/scientific-skills/research-grants/references/README.md
+++ b/scientific-skills/research-grants/references/README.md
@@ -115,9 +115,9 @@ For in-depth help on specific components:
 ### Specialized Guides
 - `references/broader_impacts.md` - NSF broader impacts strategies
 - `references/specific_aims_guide.md` - NIH Specific Aims page mastery
-- `references/budget_preparation.md` - Budget development (coming soon)
-- `references/review_criteria.md` - Comparative review criteria (coming soon)
-- `references/timeline_planning.md` - Project management (coming soon)
+- `references/budget_preparation.md` - Budget development, justification, and agency-specific budgeting strategy
+- `references/review_criteria.md` - Comparative review criteria across NSF, NIH, DOE, DARPA, and NSTC
+- `references/timeline_planning.md` - Project timelines, milestones, decision points, and schedule design
 
 ### Templates
 - `assets/nsf_project_summary_template.md`

--- a/scientific-skills/research-grants/references/budget_preparation.md
+++ b/scientific-skills/research-grants/references/budget_preparation.md
@@ -1,0 +1,228 @@
+# Budget Preparation for Research Grants
+
+## Overview
+
+A grant budget is not an accounting appendix. It is part of the scientific argument. Reviewers use the budget to judge whether the scope is realistic, whether the team is appropriately staffed, and whether the investigators understand what the work will actually require.
+
+**Core principle**: build the budget from the research plan, not the other way around. Every major line item should map to an activity, milestone, or deliverable in the proposal.
+
+## Start with Scope, Not Spreadsheets
+
+Before drafting numbers, define:
+
+- the aims or work packages
+- the personnel needed for each phase
+- the equipment, data, and software requirements
+- travel or fieldwork constraints
+- collaborator or subaward responsibilities
+- compliance or regulatory costs
+
+If the scope is vague, the budget will be vague. If the budget is vague, reviewers often infer that the project plan is weak.
+
+## Standard Budget Categories
+
+### Personnel
+
+Personnel is usually the most important section of the budget.
+
+Typical roles include:
+
+- PI and co-investigators
+- postdoctoral researchers
+- graduate students
+- research assistants or technicians
+- project managers or coordinators
+- software engineers, data managers, or statisticians
+
+For each role, justify:
+
+- why that expertise is necessary
+- what fraction of effort is realistic
+- which work package or aim the role supports
+
+### Equipment
+
+Request equipment only when it is clearly necessary and cannot reasonably be accessed through existing institutional resources.
+
+Explain:
+
+- what the equipment is
+- why it is needed for the proposed work
+- why shared facilities are insufficient
+- when in the timeline it is required
+
+### Materials and Supplies
+
+This category often includes:
+
+- reagents and consumables
+- sample preparation costs
+- laboratory animals or cell culture materials
+- cloud storage or compute credits
+- software licenses when not already institutionally covered
+
+Be specific enough that the reviewer can understand what the supplies are supporting, but not so granular that the justification reads like an internal purchasing log.
+
+### Travel
+
+Travel usually falls into three groups:
+
+- project travel for fieldwork, data collection, or collaboration
+- required program meetings
+- dissemination travel such as conferences
+
+Justify travel in terms of project execution or research impact.
+
+### Subawards and Consultants
+
+Use subawards when another institution is doing a meaningful part of the work. Use consultants for narrower, time-bounded expertise.
+
+Clarify:
+
+- who is responsible for which part of the work
+- why the expertise is external
+- what deliverable or decision point depends on it
+
+### Other Direct Costs
+
+Depending on the project, this may include:
+
+- participant compensation
+- publication and open-access costs
+- data acquisition fees
+- specialized core facility usage
+- transcription or translation
+- secure data enclave fees
+
+## Budget Strategy by Agency
+
+### NSF
+
+NSF budgets should show a clear relationship to the project description and broader impacts plan.
+
+Pay attention to:
+
+- student support and training
+- educational and outreach activities
+- summer salary limitations
+- whether cost sharing is allowed or discouraged in the program
+
+### NIH
+
+NIH budgets are tightly connected to feasibility and approach.
+
+Pay attention to:
+
+- whether staffing is adequate for the proposed rigor
+- whether protected effort for the PI is credible
+- whether sample sizes, assays, and analysis support align with requested funds
+- whether multi-year effort matches the pace of the work
+
+### DOE
+
+DOE budgets often benefit from a clear connection to facilities, instrumentation, or computational resources.
+
+Pay attention to:
+
+- user facility access
+- instrument time
+- national lab collaboration costs
+- milestone-driven staffing
+- cost sharing requirements where applicable
+
+### DARPA
+
+DARPA budgets are often reviewed for realism, phase structure, and management discipline.
+
+Pay attention to:
+
+- phase-specific work breakdown
+- milestone and demonstration costs
+- prototype development or testbed expenses
+- travel to reviews and program meetings
+- explicit deliverables tied to spending
+
+### NSTC
+
+For NSTC-style proposals, make sure the budget supports both technical execution and reporting requirements. Reviewers will care whether staffing, equipment, and milestones make the work look feasible and well-managed.
+
+## How to Write a Strong Budget Justification
+
+For each category, answer three questions:
+
+1. What is being requested?
+2. Why is it necessary for this project?
+3. Why is the requested scale reasonable?
+
+Good justifications tend to be:
+
+- concrete
+- tied to aims and methods
+- proportional to project scope
+- written in plain language
+
+Avoid:
+
+- generic phrases like "to support the project"
+- padding with nonessential purchases
+- unexplained FTEs or role duplication
+- equipment requests with no corresponding method section need
+
+## Common Red Flags Reviewers Notice
+
+- too much work for too little staffing
+- too much staffing for a narrow or vague scope
+- major methods with no budget support
+- outreach or broader impacts described but not funded
+- expensive equipment without justification
+- multi-site projects with no coordination budget
+- unrealistic travel or dissemination claims
+- budget numbers that contradict the timeline
+
+## Practical Budget Workflow
+
+### Step 1: Map each aim to activities
+
+List the concrete work under each aim:
+
+- experiments or analyses
+- recruitment or data collection
+- software or pipeline development
+- meetings and coordination
+- dissemination outputs
+
+### Step 2: Map activities to people and resources
+
+For each activity, identify:
+
+- who will do it
+- how long it takes
+- what tools or materials are required
+
+### Step 3: Phase the work by year
+
+The budget should reflect when costs happen. Do not distribute the same pattern blindly across years if the scientific work is front-loaded or back-loaded.
+
+### Step 4: Stress-test feasibility
+
+Ask:
+
+- can this team actually deliver the scope with this level of effort?
+- does the budget make the project look disciplined or inflated?
+- would an external reviewer believe these milestones on this staffing model?
+
+## Final Checklist
+
+Before submission, confirm that:
+
+- every major budget line is justified in the narrative
+- every major promise in the narrative has budget support
+- effort levels are consistent across forms and biosketches
+- timeline, milestones, and staffing agree
+- subaward roles are clearly separated
+- travel and equipment requests are defensible
+- agency-specific constraints have been checked
+
+## Bottom Line
+
+A strong budget tells reviewers that the science is planned, the team is disciplined, and the project can actually be executed. A weak budget makes even good science look risky.

--- a/scientific-skills/research-grants/references/review_criteria.md
+++ b/scientific-skills/research-grants/references/review_criteria.md
@@ -1,0 +1,193 @@
+# Comparative Review Criteria for Research Grants
+
+## Overview
+
+Grant reviewers are not only asking whether the science is interesting. They are asking whether the proposal matches the agency's definition of "fundable." That definition varies substantially across NSF, NIH, DOE, DARPA, and NSTC.
+
+**Core principle**: write to the review criteria explicitly. If a criterion matters, do not assume reviewers will infer it.
+
+## Quick Comparison
+
+| Agency | What reviewers emphasize most |
+| --- | --- |
+| NSF | Intellectual Merit and Broader Impacts, both clearly and substantively addressed |
+| NIH | Significance, Innovation, Approach, Investigator, and Environment |
+| DOE | Technical merit, mission relevance, team capability, and resource realism |
+| DARPA | Transformative impact, technical ambition, executable milestones, and transition value |
+| NSTC | Innovation, feasibility, PI capability, and research value |
+
+## NSF Review Criteria
+
+### Intellectual Merit
+
+Reviewers want to know:
+
+- does this advance knowledge?
+- is the research question important and clear?
+- is the approach rigorous and well organized?
+- does the team have access to the needed resources?
+
+### Broader Impacts
+
+Reviewers want to know:
+
+- who benefits beyond the immediate research team?
+- are the broader impacts real, measurable, and resourced?
+- are they integrated with the project instead of bolted on?
+
+Weak NSF proposals often fail here even when the science is strong.
+
+## NIH Review Criteria
+
+### Significance
+
+Reviewers ask:
+
+- does the project address an important problem?
+- if it succeeds, will the field or practice change meaningfully?
+
+### Innovation
+
+Reviewers ask:
+
+- is the proposal novel in question, method, or framework?
+- does it go beyond routine extension of prior work?
+
+### Approach
+
+This is frequently the most decisive criterion.
+
+Reviewers ask:
+
+- are the methods appropriate?
+- is the study design rigorous?
+- are risks acknowledged and handled?
+- are the milestones realistic?
+
+### Investigator and Environment
+
+Reviewers ask:
+
+- is this the right team?
+- does the institutional environment support success?
+
+For NIH, a proposal with strong significance but weak approach usually scores poorly.
+
+## DOE Review Criteria
+
+DOE offices differ, but several patterns are common.
+
+Reviewers often emphasize:
+
+- scientific or technical merit
+- alignment with DOE mission or office priorities
+- quality of the execution plan
+- qualifications of the investigators
+- adequacy of facilities and computational resources
+- budget realism
+
+## DARPA Review Criteria
+
+DARPA proposals are not conventional academic proposals.
+
+Reviewers often ask:
+
+- is the problem worth solving at DARPA scale?
+- is the idea genuinely ambitious?
+- what is the measurable technical payoff?
+- can this team execute under milestone pressure?
+- what happens if it works?
+
+For DARPA, feasibility matters, but so does boldness. Proposals that are safe but incremental often underperform.
+
+## NSTC Review Criteria
+
+NSTC-style review usually centers on:
+
+- innovation
+- feasibility
+- PI capability
+- academic or societal value
+
+A common failure mode is strong ambition with weak evidence that the plan can actually be delivered.
+
+## How to Write Directly to Review Criteria
+
+### 1. Mirror the criteria in your structure
+
+If the agency evaluates significance, innovation, and approach separately, make those parts unmistakable in the writing.
+
+### 2. Make the evidence visible
+
+Do not merely claim:
+
+- "This work is innovative"
+- "The team is well qualified"
+- "The plan is rigorous"
+
+Show the evidence:
+
+- why the idea is non-obvious
+- which prior results establish readiness
+- how the team's track record matches the aims
+
+### 3. Reduce reviewer workload
+
+Reviewers are reading many proposals. Make the answers easy to spot:
+
+- strong topic sentences
+- clear section headings
+- concise summaries
+- figures where they improve comprehension
+
+### 4. Tie budget and timeline to criteria
+
+Reviewers use budget and timeline as indirect evidence for feasibility. If the staffing, milestones, and requested funds do not align, "approach" and "capability" are damaged even before they reach the science.
+
+## Common Reviewer Failure Modes by Criterion
+
+### Significance Failure
+
+- the problem feels narrow or low-value
+- the payoff is underspecified
+- the proposal does not explain why now
+
+### Innovation Failure
+
+- the proposal repackages standard methods
+- the novelty is incremental but oversold
+- the proposal uses fashionable language without a real conceptual advance
+
+### Approach Failure
+
+- no clear study design
+- sample size or data strategy is vague
+- risks are ignored
+- alternative paths are missing
+- timeline is implausible
+
+### Team Failure
+
+- key expertise is missing
+- collaborations are decorative rather than necessary
+- the proposal depends on capacities not demonstrated anywhere
+
+### Impact Failure
+
+- broader impacts are generic
+- transition plans are vague
+- dissemination is mentioned but not designed
+
+## Review-Ready Checklist
+
+Before submission, ask:
+
+- can a reviewer identify each major criterion in under a minute?
+- is there direct evidence for significance, innovation, and feasibility?
+- does the team description match the technical demands?
+- does the timeline reinforce credibility?
+- does the budget look like it belongs to this exact project?
+
+## Bottom Line
+
+Review criteria are not a box-checking exercise. They are the lens through which reviewers interpret everything else in the proposal. A competitive grant application makes those answers explicit and easy to verify.

--- a/scientific-skills/research-grants/references/timeline_planning.md
+++ b/scientific-skills/research-grants/references/timeline_planning.md
@@ -1,0 +1,213 @@
+# Timeline Planning and Milestone Design for Research Grants
+
+## Overview
+
+A strong proposal timeline shows that the work is sequenced, staffed, and achievable. It reassures reviewers that the project is not just scientifically interesting, but operationally credible.
+
+**Core principle**: the timeline should reflect dependencies, decision points, and deliverables, not just divide work evenly across years.
+
+## What a Good Timeline Must Demonstrate
+
+Reviewers should be able to see:
+
+- when each major activity starts and ends
+- which tasks depend on earlier tasks
+- what constitutes progress
+- who is responsible for key milestones
+- what happens if the original plan slips
+
+## Standard Timeline Elements
+
+### Work Packages or Aims
+
+Break the project into a small number of meaningful units:
+
+- Aim 1, Aim 2, Aim 3
+- Work Package A, B, C
+- Phase I, II, III
+
+Each unit should have:
+
+- a purpose
+- a lead owner
+- concrete outputs
+- a rough start and end period
+
+### Milestones
+
+Milestones should mark meaningful progress, such as:
+
+- dataset assembled and quality controlled
+- prototype instrument calibrated
+- recruitment target reached
+- model benchmark completed
+- manuscript or software release delivered
+
+Weak milestones are activity-only statements like "continue analysis."
+
+### Decision Points
+
+Decision points are especially important in high-risk work. They show that the team will adapt if assumptions fail.
+
+Examples:
+
+- proceed to animal model only if in vitro effect size exceeds threshold
+- expand cohort only if initial signal replicates
+- pivot to backup method if assay reproducibility remains below target
+
+### Deliverables
+
+Deliverables are what the project produces:
+
+- datasets
+- software
+- models
+- protocols
+- demonstrations
+- publications
+- policy briefs
+
+## Common Timeline Formats
+
+### Gantt Chart
+
+Best when you need to show overlap and dependencies.
+
+### Year-by-Year Narrative
+
+Best when the agency expects prose and not every reviewer wants to parse a chart.
+
+### Table Format
+
+Useful when you want to show alignment among:
+
+- task
+- timeline
+- personnel
+- milestone
+- deliverable
+
+## Timeline Strategy by Proposal Type
+
+### Exploratory or High-Risk Projects
+
+Show:
+
+- early proof-of-feasibility milestones
+- clear go/no-go criteria
+- fallback methods
+
+### Data-Intensive or Computational Projects
+
+Show:
+
+- data acquisition and cleaning first
+- infrastructure and pipeline setup early
+- validation before final model claims
+- release and documentation near the end
+
+### Experimental or Wet-Lab Projects
+
+Show:
+
+- assay development or optimization first
+- pilot studies before scaling
+- replication and validation explicitly
+- time for troubleshooting and regulatory delays
+
+### Collaborative Multi-Site Projects
+
+Show:
+
+- coordination milestones
+- handoff points between institutions
+- data sharing cadence
+- integration checkpoints
+
+## Agency-Specific Nuance
+
+### NSF
+
+For NSF, timelines should support both the research plan and the broader impacts plan. If outreach, education, or training are substantive, they should appear in the timeline as real work, not side notes.
+
+### NIH
+
+For NIH, timelines need to reinforce feasibility of the approach. They should make it obvious that the aims are achievable within the project period and that preliminary dependencies are understood.
+
+### DOE
+
+For DOE, reviewers may expect timelines to align with facilities access, instrumentation constraints, or phased technical objectives. Quantitative milestones can help.
+
+### DARPA
+
+For DARPA, milestone discipline is especially important. Timelines should feel program-managed, with measurable checkpoints and clear phase logic.
+
+### NSTC
+
+For NSTC, a coherent timeline helps demonstrate feasibility and project discipline. Make the progression of tasks, outputs, and team responsibilities very explicit.
+
+## Common Timeline Mistakes
+
+- every year looks identical
+- no relation between aims and milestones
+- all major outputs appear at the very end
+- no time allocated for setup, validation, or approvals
+- no contingency for known risks
+- collaboration tasks are invisible
+- dissemination is missing
+
+## Practical Workflow for Building a Timeline
+
+### Step 1: List the real tasks
+
+Start from the methods, not from a generic template.
+
+### Step 2: Identify dependencies
+
+Ask:
+
+- what must be done before this task can start?
+- what can run in parallel?
+- what is the critical path?
+
+### Step 3: Turn tasks into milestones
+
+Convert passive activities into milestone language.
+
+### Step 4: Assign ownership
+
+Every major milestone should have a responsible role:
+
+- PI
+- co-I
+- postdoc
+- engineer
+- data manager
+
+### Step 5: Add contingency space
+
+Projects almost always slip somewhere. A timeline that leaves no room for iteration or setbacks often looks naive.
+
+## Simple Timeline Template
+
+| Period | Main activities | Milestones | Lead |
+| --- | --- | --- | --- |
+| Year 1 / Q1-Q2 | Setup, pilot work, approvals | Infrastructure ready; pilot benchmark completed | PI + engineer |
+| Year 1 / Q3-Q4 | Core data collection or model development | Initial dataset or prototype validated | postdoc |
+| Year 2 | Full-scale execution and validation | Aim 1 complete; decision gate passed | PI + team |
+| Year 3 | Integration, dissemination, translation | Final analyses, release package, manuscripts | PI + co-Is |
+
+## Reviewer-Facing Checklist
+
+Before submission, confirm that:
+
+- the timeline matches the aims
+- milestones are observable and meaningful
+- dependencies are realistic
+- staffing aligns with the pace of work
+- broader impacts or dissemination are scheduled, not implied
+- the budget and timeline tell the same story
+
+## Bottom Line
+
+A timeline is not decorative. It is one of the clearest signals that the project is organized, feasible, and worth funding. Strong proposals use it to reduce perceived execution risk before reviewers have to ask for reassurance.


### PR DESCRIPTION
## Summary
- add three missing `research-grants` reference guides for budget preparation, comparative review criteria, and timeline planning
- wire the new guides into `scientific-skills/research-grants/SKILL.md`
- update `scientific-skills/research-grants/references/README.md` so these guides are no longer listed as "coming soon"

## Why
The `research-grants` skill already advertised these reference topics, but the underlying files were missing. This PR makes those references real and keeps the skill documentation internally consistent.

## Scope
This PR intentionally stays within the `scientific-skills/research-grants/` skill and does not change repository-wide tooling or unrelated skills.

_Drafting assistance from Codex; content selection, review, and final submission done by me._