### PR TITLE
fix: remove doubled uv prefix in install commands (uv uv pip → uv pip)

### DIFF
--- a/scientific-skills/fluidsim/SKILL.md
+++ b/scientific-skills/fluidsim/SKILL.md
@@ -26,13 +26,13 @@ Install fluidsim using uv with appropriate feature flags:
 
 ```bash
 # Basic installation
-uv uv pip install fluidsim
+uv pip install fluidsim
 
 # With FFT support (required for most solvers)
-uv uv pip install "fluidsim[fft]"
+uv pip install "fluidsim[fft]"
 
 # With MPI for parallel computing
-uv uv pip install "fluidsim[fft,mpi]"
+uv pip install "fluidsim[fft,mpi]"
 ```
 
 Set environment variables for output directories (optional):

--- a/scientific-skills/geniml/SKILL.md
+++ b/scientific-skills/geniml/SKILL.md
@@ -17,19 +17,19 @@ Geniml is a Python package for building machine learning models on genomic inter
 Install geniml using uv:
 
 ```bash
-uv uv pip install geniml
+uv pip install geniml
 ```
 
 For ML dependencies (PyTorch, etc.):
 
 ```bash
-uv uv pip install 'geniml[ml]'
+uv pip install 'geniml[ml]'
 ```
 
 Development version from GitHub:
 
 ```bash
-uv uv pip install git+https://github.com/databio/geniml.git
+uv pip install git+https://github.com/databio/geniml.git
 ```
 
 ## Core Capabilities

--- a/scientific-skills/gtars/SKILL.md
+++ b/scientific-skills/gtars/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when working with:
 Install gtars Python bindings:
 
 ```bash
-uv uv pip install gtars
+uv pip install gtars
 ```
 
 ### CLI Installation

--- a/scientific-skills/pyopenms/SKILL.md
+++ b/scientific-skills/pyopenms/SKILL.md
@@ -17,7 +17,7 @@ PyOpenMS provides Python bindings to the OpenMS library for computational mass s
 Install using uv:
 
 ```bash
-uv uv pip install pyopenms
+uv pip install pyopenms
 ```
 
 Verify installation:

--- a/scientific-skills/scikit-learn/SKILL.md
+++ b/scientific-skills/scikit-learn/SKILL.md
@@ -16,13 +16,13 @@ This skill provides comprehensive guidance for machine learning tasks using scik
 
 ```bash
 # Install scikit-learn using uv
-uv uv pip install scikit-learn
+uv pip install scikit-learn
 
 # Optional: Install visualization dependencies
-uv uv pip install matplotlib seaborn
+uv pip install matplotlib seaborn
 
 # Commonly used with
-uv uv pip install pandas numpy
+uv pip install pandas numpy
 ```
 
 ## When to Use This Skill


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Five skills contain invalid installation commands where `uv` appears twice: `uv uv pip install <pkg>`. This is not a valid shell invocation — `uv uv` is not a recognized subcommand — and will fail immediately for any user who copies the command verbatim.

**Affected skills and occurrences:**
- `scikit-learn/SKILL.md` — 3 instances (`scikit-learn`, `matplotlib seaborn`, `pandas numpy`)
- `pyopenms/SKILL.md` — 1 instance
- `fluidsim/SKILL.md` — 3 instances (base, `[fft]`, `[fft,mpi]` variants)
- `gtars/SKILL.md` — 1 instance
- `geniml/SKILL.md` — 3 instances (base, `[ml]` extra, git install)

## Fix

Replaced all `uv uv pip install` occurrences with the correct `uv pip install`. No other changes were made.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-invalid-install-cmd","fingerprint":"sha256:85a2114ddd0bbc0b1a57803612a39c7e5f7465ece00f99c3d89d0cad4c817fd1"},{"rule_id":"BUG-invalid-install-cmd","fingerprint":"sha256:1e7a6fffcb89db4fca2708db65903ecc09b220a7dec51d93d9e3d71d4dd89830"},{"rule_id":"BUG-invalid-install-cmd","fingerprint":"sha256:2e8c2aa952c894ffac127011fe1bf58f6c0a18bca92b4abe7d7c2167f2634fdb"},{"rule_id":"BUG-invalid-install-cmd","fingerprint":"sha256:e39d1245ffa697465f5f833a15f3d32a800f2dd99c774c7f7e404bcf4ceb3917"},{"rule_id":"BUG-invalid-install-cmd","fingerprint":"sha256:3dd8b1ed7a4bc5f08bf5cd9b1d2b28f7b67156ea8a84055c13e65a9b95ad3925"}]}
nlpm-metadata-end -->