### PR TITLE
fix: correct uv invocation in latchbio-integration install command

### DIFF
--- a/scientific-skills/latchbio-integration/SKILL.md
+++ b/scientific-skills/latchbio-integration/SKILL.md
@@ -50,7 +50,7 @@ The Latch platform provides four main areas of functionality:
 
 ```bash
 # Install Latch SDK
-python3 -m uv pip install latch
+uv pip install latch
 
 # Login to Latch
 latch login


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`latchbio-integration/SKILL.md` installs the Latch SDK with:

```bash
python3 -m uv pip install latch
```

This invokes `uv` as a Python module (`python3 -m uv`), which is not the standard or documented way to call uv. Users may not have uv installed as a Python-importable module, and this invocation can fail depending on the local Python and uv installation method.

## Fix

Replaced with the correct direct invocation:

```bash
uv pip install latch
```

This is consistent with the installation pattern used throughout the rest of the skill collection.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-invalid-install-cmd","fingerprint":"sha256:801c2a9c35dcc5a44abcb504ed34d5ae28a7b91e39c02b67b9088ee08a5e6751"}]}
nlpm-metadata-end -->