### PR TITLE
fix: correct scanpy license typo (SD-3-Clause → BSD-3-Clause)

### DIFF
--- a/scientific-skills/scanpy/SKILL.md
+++ b/scientific-skills/scanpy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scanpy
 description: Standard single-cell RNA-seq analysis pipeline. Use for QC, normalization, dimensionality reduction (PCA/UMAP/t-SNE), clustering, differential expression, and visualization. Best for exploratory scRNA-seq analysis with established workflows. For deep learning models use scvi-tools; for data format questions use anndata.
-license: SD-3-Clause license
+license: BSD-3-Clause
 metadata:
     skill-author: K-Dense Inc.
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`scanpy/SKILL.md` has a malformed license identifier in its frontmatter:

```yaml
license: SD-3-Clause license
```

This has two problems: the leading `B` is missing (making it an unrecognized identifier), and it includes a trailing ` license` word that is not part of any SPDX identifier. Scanpy is licensed under the BSD 3-Clause license.

## Fix

Corrected to the proper SPDX identifier:

```yaml
license: BSD-3-Clause
```

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-license-typo","fingerprint":"sha256:2f25560e64d08256d948e737e3fa93e1a2b0865b5a13a52dee96cb6ea7f9cd22"}]}
nlpm-metadata-end -->