### PR TITLE
fix: disclose data transmission to openrouter.ai in scientific-schematics

### DIFF
--- a/scientific-skills/scientific-schematics/SKILL.md
+++ b/scientific-skills/scientific-schematics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scientific-schematics
-description: Create publication-quality scientific diagrams using Nano Banana 2 AI with smart iterative refinement. Uses Gemini 3.1 Pro Preview for quality review. Only regenerates if quality is below threshold for your document type. Specialized in neural network architectures, system diagrams, flowcharts, biological pathways, and complex scientific visualizations.
+description: Create publication-quality scientific diagrams using Nano Banana 2 AI with smart iterative refinement. Uses Gemini 3.1 Pro Preview for quality review. Only regenerates if quality is below threshold for your document type. Specialized in neural network architectures, system diagrams, flowcharts, biological pathways, and complex scientific visualizations. Requires OPENROUTER_API_KEY; diagram prompts and quality-review queries are transmitted to openrouter.ai.
 allowed-tools: Read Write Edit Bash
 license: MIT license
 metadata:


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium — disclosure gap)

`scientific-schematics/scripts/generate_schematic_ai.py` makes HTTPS POST requests to `https://openrouter.ai/api/v1`, transmitting the user's natural-language diagram description and quality-review prompts to a third-party commercial service. The `OPENROUTER_API_KEY` requirement is correctly documented in the body of the skill, but the **frontmatter `description` field** — the part users see when choosing whether to load a skill — did not disclose this data transmission.

Users discovering the API key requirement at runtime, rather than at skill-selection time, may be caught off guard and cannot make an informed consent decision before their prompt text leaves the local machine.

## Fix

Added a single sentence to the frontmatter `description`:

> Requires OPENROUTER_API_KEY; diagram prompts and quality-review queries are transmitted to openrouter.ai.

This ensures the disclosure is present in the skill's summary, consistent with the detailed setup instructions already present in the body.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-outbound-api-call","fingerprint":"sha256:45321922426b0798ea5ce2ca786c9e8e0b29623bf3729ba649d444f9f9dc7215"}]}
nlpm-metadata-end -->