### PR TITLE
fix: disclose data transmission to api.parallel.ai and openrouter.ai in research-lookup

### DIFF
--- a/scientific-skills/research-lookup/SKILL.md
+++ b/scientific-skills/research-lookup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-lookup
-description: Look up current research information using parallel-cli search (primary, fast web search), the Parallel Chat API (deep research), or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information.
+description: Look up current research information using parallel-cli search (primary, fast web search), the Parallel Chat API (deep research), or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information. Note: query text is transmitted to api.parallel.ai (PARALLEL_API_KEY) and, for academic searches, to openrouter.ai (OPENROUTER_API_KEY).
 allowed-tools: Read Write Edit Bash
 license: MIT license
 compatibility: parallel-cli required (primary); PARALLEL_API_KEY and OPENROUTER_API_KEY optional for deep/academic backends


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium — disclosure gap)

`research-lookup/research_lookup.py` transmits user research query text to two separate commercial services:
1. **`https://api.parallel.ai`** — the Parallel Chat API backend (via `PARALLEL_API_KEY`)
2. **`https://openrouter.ai/api/v1`** — the Perplexity sonar-pro-search backend (via `OPENROUTER_API_KEY`)

The `compatibility` frontmatter field correctly lists the required API keys, and the skill body explains the backend routing in detail. However, the **`description` field** — the first thing users see when deciding whether to load this skill — did not mention that query text leaves the local machine to these commercial services.

## Fix

Added a brief disclosure sentence to the frontmatter `description`:

> Note: query text is transmitted to api.parallel.ai (PARALLEL_API_KEY) and, for academic searches, to openrouter.ai (OPENROUTER_API_KEY).

This surfaces the data-transmission disclosure at the point of skill selection, consistent with the backend routing details already documented in the skill body.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-outbound-api-call","fingerprint":"sha256:98640a5ad3e27d2352e3762404176390fca8340cf1cc8a2d6524273e2f284d4e"}]}
nlpm-metadata-end -->