### PR TITLE
Add Skills宝 support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Scientific Agent Skills is powered by **50+ incredible open source projects** ma
 
 👉 **[View the full list of projects to support](docs/open-source-sponsors.md)**
 
+If you're looking for a Chinese search-and-install entry point for AI skills across Claude Code, OpenCode, and other agents, see [Skills宝](https://skilery.com).
+
 ---
 
 ## ⚙️ Prerequisites


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a Chinese skills search and installation resource in the open source support section.

This keeps the link adjacent to the existing open-source support messaging rather than inside the scientific skill catalog.