### PR TITLE
docs: add missing research grants references

### DIFF
--- a/scientific-skills/research-grants/references/budget_preparation.md
+++ b/scientific-skills/research-grants/references/budget_preparation.md
@@ -1,0 +1,42 @@
+# Budget Preparation for Research Grants
+
+## Purpose
+
+The budget translates the research plan into a credible resource plan. Reviewers and program staff use it to judge whether the scope, staffing, timeline, and requested funds are aligned.
+
+## Core Budget Categories
+
+- **Personnel**: PI, co-investigators, staff, postdocs, students, consultants, and fringe benefits.
+- **Equipment**: Durable items that meet the agency and institutional equipment threshold.
+- **Materials and supplies**: Consumables, reagents, software, cloud credits, and lab supplies.
+- **Travel**: Fieldwork, collaboration visits, required meetings, and conference dissemination.
+- **Participant or patient costs**: Recruitment, incentives, clinical costs, and related services.
+- **Publication and dissemination**: Open-access fees, data hosting, workshops, and outreach.
+- **Subawards**: Collaborating institution work with their own direct and indirect costs.
+- **Indirect costs**: Facilities and administrative costs under the institutional negotiated rate.
+
+## Preparation Workflow
+
+1. Build the work breakdown from aims, tasks, milestones, and deliverables.
+2. Map each task to people, effort, supplies, services, equipment, and travel.
+3. Check agency caps, unallowable costs, cost-sharing rules, and budget format.
+4. Validate institutional rates for salary escalation, fringe, tuition, and indirect costs.
+5. Reconcile the budget against the narrative, timeline, biosketches, and facilities section.
+
+## Budget Justification Checklist
+
+- Every major cost is necessary for a named task or milestone.
+- Personnel effort matches roles described in the project plan.
+- Equipment requests explain why existing resources are insufficient.
+- Travel has a clear project purpose, not generic conference attendance.
+- Subawards include a distinct scope of work and responsible lead.
+- Year-to-year changes are explained.
+- Cost sharing is included only when required or strategically justified.
+
+## Common Pitfalls
+
+- Asking for resources not mentioned in the research strategy.
+- Under-budgeting staff time for data management, compliance, or coordination.
+- Omitting publication, computing, storage, animal, participant, or core facility costs.
+- Using unexplained round numbers.
+- Ignoring agency-specific caps or modular budget constraints.

--- a/scientific-skills/research-grants/references/funding_mechanisms.md
+++ b/scientific-skills/research-grants/references/funding_mechanisms.md
@@ -1,0 +1,42 @@
+# Funding Mechanisms Overview
+
+## NIH
+
+- **R01**: Mature research project, typically 3-5 years, substantial preliminary data expected.
+- **R21**: Exploratory or high-risk work, shorter and smaller than an R01.
+- **R03**: Small grants for limited-scope projects.
+- **K awards**: Career development awards with mentoring and training plans.
+- **F awards**: Individual fellowships for predoctoral or postdoctoral trainees.
+- **U mechanisms**: Cooperative agreements with substantial NIH program involvement.
+
+## NSF
+
+- **Core research programs**: Investigator-initiated proposals within directorate programs.
+- **CAREER**: Early-career faculty award integrating research and education.
+- **EAGER**: Exploratory, high-risk, potentially transformative work.
+- **RAPID**: Urgent research with time-sensitive opportunity.
+- **Center or institute programs**: Larger, collaborative, multi-investigator efforts.
+
+## DOE
+
+- **Office of Science FOAs**: Basic research aligned with office priorities.
+- **Early Career Research Program**: Support for outstanding early-career scientists.
+- **ARPA-E**: High-risk energy technology with commercialization or transition potential.
+- **National laboratory collaborations**: Mechanisms involving DOE lab capabilities or user facilities.
+
+## DARPA
+
+- **BAA responses**: Program-specific proposals against broad agency announcements.
+- **Seedlings or exploratory calls**: Shorter early-stage efforts when available.
+- **Young Faculty Award**: Early-career faculty with high-risk ideas relevant to DARPA.
+
+## Selection Guidance
+
+Choose a mechanism by matching:
+
+- Project maturity and preliminary data.
+- Risk level and expected payoff.
+- Team career stage.
+- Budget and duration needs.
+- Agency mission fit.
+- Review culture and success criteria.

--- a/scientific-skills/research-grants/references/research_methods.md
+++ b/scientific-skills/research-grants/references/research_methods.md
@@ -1,0 +1,37 @@
+# Research Methods in Grant Proposals
+
+## Purpose
+
+The methods section persuades reviewers that the proposed work can answer the research question with rigor, feasibility, and appropriate controls.
+
+## Essential Components
+
+- Study design or experimental design.
+- Data sources, samples, subjects, systems, or models.
+- Inclusion, exclusion, randomization, blinding, and control conditions where relevant.
+- Measurements, instruments, assays, algorithms, or protocols.
+- Statistical or computational analysis plan.
+- Power, sample size, uncertainty, and sensitivity analysis where appropriate.
+- Rigor, reproducibility, validation, and quality control.
+- Alternative approaches for the most likely failure modes.
+
+## Experimental Research
+
+Describe biological or physical systems, controls, replicates, reagents, equipment, outcome measures, and analysis methods. Make clear which data support each hypothesis or aim.
+
+## Computational Research
+
+Describe datasets, preprocessing, model design, baselines, validation splits, metrics, error analysis, compute resources, software availability, and reproducibility plan.
+
+## Clinical or Translational Research
+
+Describe population, recruitment, consent, intervention or exposure, endpoints, monitoring, safety, regulatory approvals, and statistical analysis.
+
+## Reviewer Checks
+
+- Does each aim have a concrete method?
+- Are controls and comparisons sufficient?
+- Are sample sizes justified?
+- Are assumptions explicit?
+- Are risks and alternatives credible?
+- Can another expert reproduce the work from the description?

--- a/scientific-skills/research-grants/references/resubmission_strategies.md
+++ b/scientific-skills/research-grants/references/resubmission_strategies.md
@@ -1,0 +1,41 @@
+# Resubmission Strategies
+
+## Purpose
+
+A resubmission should show that the team understood reviewer concerns, made substantive improvements, and preserved the proposal's central value.
+
+## First Step
+
+Read the reviews in three passes:
+
+1. Identify fatal concerns versus fixable presentation issues.
+2. Group comments by theme: significance, innovation, approach, team, environment, budget.
+3. Decide whether to revise, redirect to another mechanism, or build more preliminary data first.
+
+## NIH A1 Resubmissions
+
+- Use the introduction page to summarize major changes.
+- Address all major critiques respectfully and specifically.
+- Make changes visible through rewritten sections, not track changes.
+- Strengthen preliminary data, rigor, statistics, or alternatives where requested.
+- Do not argue with reviewers unless correcting a factual misunderstanding.
+
+## NSF Resubmissions
+
+NSF has no universal formal introduction page. Incorporate reviewer feedback into the revised narrative, especially around intellectual merit, broader impacts, feasibility, and clarity.
+
+## Strong Response Patterns
+
+- "We clarified..." for communication problems.
+- "We added preliminary data..." for feasibility concerns.
+- "We revised Aim 2..." for design concerns.
+- "We added an alternative strategy..." for risk concerns.
+- "We recruited collaborator X..." for expertise gaps.
+
+## When Not to Resubmit Immediately
+
+- Reviewers rejected the premise rather than the execution.
+- The mechanism or program fit was poor.
+- Essential preliminary data are missing.
+- The team lacks required expertise.
+- The budget or timeline is not credible without scope reduction.

--- a/scientific-skills/research-grants/references/review_criteria.md
+++ b/scientific-skills/research-grants/references/review_criteria.md
@@ -1,0 +1,45 @@
+# Comparative Review Criteria
+
+## NSF
+
+NSF proposals are reviewed on **Intellectual Merit** and **Broader Impacts**. Strong proposals make both criteria explicit in the project summary, project description, and evaluation plan.
+
+- Intellectual Merit: importance, originality, technical rigor, qualifications, and resources.
+- Broader Impacts: societal benefit, education, workforce development, participation, dissemination, and infrastructure.
+
+## NIH
+
+Most NIH research project grants receive an overall impact score informed by five scored criteria.
+
+- Significance: importance of the problem and likely impact.
+- Investigator(s): expertise, productivity, and team suitability.
+- Innovation: conceptual, technical, or methodological novelty.
+- Approach: rigor, feasibility, alternatives, statistics, and risk handling.
+- Environment: institutional support, facilities, and collaborative setting.
+
+Reviewers also assess protections for human subjects, vertebrate animals, biohazards, authentication, data management, and rigor and reproducibility.
+
+## DOE
+
+DOE review criteria vary by office and FOA, but commonly emphasize scientific and technical merit, relevance to program mission, applicant qualifications, adequacy of resources, and reasonableness of budget.
+
+Competitive DOE proposals connect the scientific question to the office mission, national laboratory or user facility context when relevant, and measurable outcomes.
+
+## DARPA
+
+DARPA reviews focus on whether the work attacks a DARPA-hard problem with high payoff, credible technical milestones, and a path to transition.
+
+- Technical innovation and risk.
+- Potential impact if successful.
+- Measurable milestones and demonstration plan.
+- Team capability and execution speed.
+- Transition relevance to defense or national-security users.
+
+## Cross-Agency Reviewer Questions
+
+- What important problem does this solve?
+- Why is now the right time?
+- Why is this team the right team?
+- What makes the approach credible?
+- What can go wrong, and what is the fallback?
+- What will be true at the end of the award that is not true today?

--- a/scientific-skills/research-grants/references/team_building.md
+++ b/scientific-skills/research-grants/references/team_building.md
@@ -1,0 +1,39 @@
+# Team Building for Research Grants
+
+## Purpose
+
+The team section should convince reviewers that the proposed work has the right expertise, leadership, collaboration structure, and institutional support.
+
+## Team Design Questions
+
+- What expertise is essential for each aim?
+- Which roles must be senior investigators versus staff or trainees?
+- Where are the methodological, clinical, computational, or translational gaps?
+- What facilities, cores, field sites, datasets, or partnerships are required?
+- Who owns coordination, data management, compliance, and dissemination?
+
+## Roles to Define
+
+- Principal investigator or project lead.
+- Co-investigators and senior/key personnel.
+- Collaborators and consultants.
+- Project manager or coordinator.
+- Data, software, statistics, or evaluation leads.
+- Trainees and mentoring structure.
+- External advisory board, if appropriate.
+
+## Evidence of Fit
+
+- Prior publications or preliminary data in the area.
+- Complementary expertise across aims.
+- Prior collaboration or a clear collaboration plan.
+- Letters that commit specific resources or activities.
+- Institutional support, facilities, and protected time.
+
+## Common Pitfalls
+
+- Adding famous names without defined roles.
+- Missing key expertise for a high-risk method.
+- Overloading the PI with all tasks.
+- Providing generic letters of support.
+- Failing to explain how multi-site coordination will work.

--- a/scientific-skills/research-grants/references/timeline_planning.md
+++ b/scientific-skills/research-grants/references/timeline_planning.md
@@ -1,0 +1,38 @@
+# Timeline Planning for Research Grants
+
+## Purpose
+
+A timeline shows that the project is executable within the award period. It should connect aims, milestones, personnel, dependencies, deliverables, and decision points.
+
+## Timeline Elements
+
+- **Aims and tasks**: Break each aim into concrete work packages.
+- **Milestones**: Define measurable completion points, not just activities.
+- **Dependencies**: Identify tasks that require prior data, approvals, hires, or equipment.
+- **Decision points**: Specify go/no-go thresholds and alternatives.
+- **Deliverables**: Publications, datasets, software, prototypes, reports, or demonstrations.
+- **Compliance gates**: IRB, IACUC, data-use agreements, safety reviews, and export controls.
+
+## Planning Pattern
+
+1. List all aims and sub-aims.
+2. Assign each task to a quarter or project period.
+3. Add hiring, procurement, regulatory, and setup lead times.
+4. Mark dependencies between tasks.
+5. Define success metrics for each milestone.
+6. Add contingency paths for high-risk tasks.
+
+## Agency Emphasis
+
+- **NSF**: Integrate research, education, broader impacts, evaluation, and dissemination.
+- **NIH**: Show feasibility for enrollment, experiments, analysis, rigor, and data sharing.
+- **DOE**: Align tasks with program deliverables, user facilities, and reporting periods.
+- **DARPA**: Use aggressive but credible phases with quantitative milestones and demos.
+
+## Common Pitfalls
+
+- Treating the timeline as a decorative Gantt chart rather than an execution plan.
+- Scheduling major approvals after dependent work begins.
+- Omitting time for hiring, onboarding, equipment procurement, or data-use agreements.
+- Making all aims run sequentially when parallel work is possible.
+- Failing to define what happens if a milestone is missed.

--- a/tests/test_research_grants_references.py
+++ b/tests/test_research_grants_references.py
@@ -1,0 +1,14 @@
+import re
+from pathlib import Path
+
+
+def test_research_grants_markdown_references_exist():
+    skill_dir = Path(__file__).resolve().parents[1] / "scientific-skills" / "research-grants"
+    references = set()
+    for markdown_file in (skill_dir / "SKILL.md", skill_dir / "references" / "README.md"):
+        text = markdown_file.read_text(encoding="utf-8")
+        references.update(re.findall(r"`(references/[^`]+\.md)`", text))
+
+    missing = sorted(ref for ref in references if not (skill_dir / ref).exists())
+
+    assert missing == []


### PR DESCRIPTION
## Summary
- add the missing research-grants reference docs for budget, funding mechanisms, methods, resubmission, review criteria, team building, and timeline planning
- add a regression test that checks referenced research-grants markdown files exist

## Validation
- `uv run --no-sync pytest tests/test_research_grants_references.py -q`
- `git diff --check`

Fixes #118