### PR TITLE
fix(security): use defusedxml for untrusted XML inputs (billion-laughs DoS hardening)

### DIFF
--- a/scientific-skills/citation-management/scripts/extract_metadata.py
+++ b/scientific-skills/citation-management/scripts/extract_metadata.py
@@ -11,7 +11,8 @@ import argparse
 import time
 import re
 import json
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
+from xml.etree.ElementTree import Element  # nosemgrep: use-defused-xml -- Element is a data class, not a parser; defusedxml.ElementTree does not re-export it
 from typing import Optional, Dict, List, Tuple
 from urllib.parse import urlparse
 
@@ -400,7 +401,7 @@ class MetadataExtractor:
             return str(date_parts[0][0])
         return ''
     
-    def _extract_year_pubmed(self, article: ET.Element) -> str:
+    def _extract_year_pubmed(self, article: Element) -> str:
         """Extract year from PubMed XML."""
         year = article.findtext('.//Journal/JournalIssue/PubDate/Year', '')
         if not year:

--- a/scientific-skills/citation-management/scripts/search_pubmed.py
+++ b/scientific-skills/citation-management/scripts/search_pubmed.py
@@ -10,7 +10,8 @@ import requests
 import argparse
 import json
 import time
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
+from xml.etree.ElementTree import Element  # nosemgrep: use-defused-xml -- Element is a data class, not a parser; defusedxml.ElementTree does not re-export it
 from typing import List, Dict, Optional
 from datetime import datetime
 
@@ -151,7 +152,7 @@ class PubMedSearcher:
         
         return metadata_list
     
-    def _extract_metadata_from_xml(self, article: ET.Element) -> Optional[Dict]:
+    def _extract_metadata_from_xml(self, article: Element) -> Optional[Dict]:
         """Extract metadata from PubmedArticle XML element."""
         try:
             medline_citation = article.find('.//MedlineCitation')

--- a/scientific-skills/docx/scripts/office/helpers/simplify_redlines.py
+++ b/scientific-skills/docx/scripts/office/helpers/simplify_redlines.py
@@ -10,7 +10,7 @@ Rules:
 - Only merges if truly adjacent (only whitespace between them)
 """
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import zipfile
 from pathlib import Path
 

--- a/scientific-skills/docx/scripts/office/validators/redlining.py
+++ b/scientific-skills/docx/scripts/office/validators/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
             return False
 
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -74,7 +74,7 @@ class RedliningValidator:
                 return False
 
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()

--- a/scientific-skills/labarchive-integration/SKILL.md
+++ b/scientific-skills/labarchive-integration/SKILL.md
@@ -80,7 +80,7 @@ login_params = {'login_or_email': user_email, 'password': auth_token}
 response = client.make_call('users', 'user_access_info', params=login_params)
 
 # Extract UID from response
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 uid = ET.fromstring(response.content)[0].text
 
 # Get detailed user info

--- a/scientific-skills/labarchive-integration/references/authentication_guide.md
+++ b/scientific-skills/labarchive-integration/references/authentication_guide.md
@@ -105,7 +105,7 @@ login_params = {
 response = client.make_call('users', 'user_access_info', params=login_params)
 
 # Parse response to extract UID
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 uid = ET.fromstring(response.content)[0].text
 print(f"Authenticated as user ID: {uid}")
 ```
@@ -312,7 +312,7 @@ def test_authentication():
             print("✅ Authentication successful!")
 
             # Extract UID
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
             uid = ET.fromstring(response.content)[0].text
             print(f"User ID: {uid}")
 

--- a/scientific-skills/labarchive-integration/scripts/entry_operations.py
+++ b/scientific-skills/labarchive-integration/scripts/entry_operations.py
@@ -44,7 +44,7 @@ def init_client(config):
 
 def get_user_id(client, config):
     """Get user ID via authentication"""
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     login_params = {
         'login_or_email': config['user_email'],
@@ -95,7 +95,7 @@ def create_entry(client, uid, nbid, title, content=None, date=None):
 
             # Try to extract entry ID from response
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
                 root = ET.fromstring(response.content)
                 entry_id = root.find('.//entry_id')
                 if entry_id is not None:

--- a/scientific-skills/labarchive-integration/scripts/notebook_operations.py
+++ b/scientific-skills/labarchive-integration/scripts/notebook_operations.py
@@ -43,7 +43,7 @@ def init_client(config):
 
 def get_user_id(client, config):
     """Get user ID via authentication"""
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     login_params = {
         'login_or_email': config['user_email'],
@@ -68,7 +68,7 @@ def get_user_id(client, config):
 
 def list_notebooks(client, uid):
     """List all accessible notebooks for a user"""
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     print(f"\n📚 Listing notebooks for user ID: {uid}\n")
 

--- a/scientific-skills/labarchive-integration/scripts/setup_config.py
+++ b/scientific-skills/labarchive-integration/scripts/setup_config.py
@@ -113,7 +113,7 @@ def test_authentication(config_path='config.yaml'):
     try:
         # Try to import labarchives-py
         from labarchivespy.client import Client
-        import xml.etree.ElementTree as ET
+        import defusedxml.ElementTree as ET
 
         # Load config
         with open(config_path, 'r') as f:

--- a/scientific-skills/pptx/scripts/office/helpers/simplify_redlines.py
+++ b/scientific-skills/pptx/scripts/office/helpers/simplify_redlines.py
@@ -10,7 +10,7 @@ Rules:
 - Only merges if truly adjacent (only whitespace between them)
 """
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import zipfile
 from pathlib import Path
 

--- a/scientific-skills/pptx/scripts/office/validators/redlining.py
+++ b/scientific-skills/pptx/scripts/office/validators/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
             return False
 
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -74,7 +74,7 @@ class RedliningValidator:
                 return False
 
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()

--- a/scientific-skills/usfiscaldata/references/response-format.md
+++ b/scientific-skills/usfiscaldata/references/response-format.md
@@ -166,7 +166,7 @@ df = pd.read_csv(io.StringIO(resp.text))
 When `format=xml` is specified, the response body is XML:
 
 ```python
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 resp = requests.get(
     "https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v2/accounting/od/debt_to_penny",

--- a/scientific-skills/xlsx/scripts/office/helpers/simplify_redlines.py
+++ b/scientific-skills/xlsx/scripts/office/helpers/simplify_redlines.py
@@ -10,7 +10,7 @@ Rules:
 - Only merges if truly adjacent (only whitespace between them)
 """
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import zipfile
 from pathlib import Path
 

--- a/scientific-skills/xlsx/scripts/office/validators/redlining.py
+++ b/scientific-skills/xlsx/scripts/office/validators/redlining.py
@@ -29,7 +29,7 @@ class RedliningValidator:
             return False
 
         try:
-            import xml.etree.ElementTree as ET
+            import defusedxml.ElementTree as ET
 
             tree = ET.parse(modified_file)
             root = tree.getroot()
@@ -74,7 +74,7 @@ class RedliningValidator:
                 return False
 
             try:
-                import xml.etree.ElementTree as ET
+                import defusedxml.ElementTree as ET
 
                 modified_tree = ET.parse(modified_file)
                 modified_root = modified_tree.getroot()


### PR DESCRIPTION
## Summary

The skills' XML parse sites use `xml.etree.ElementTree.parse` / `fromstring` directly on user-supplied documents (`.docx`/`.pptx`/`.xlsx`) and on remote HTTP responses (PubMed E-utilities, CrossRef, arXiv, LabArchives, Treasury fiscaldata API). Python's stdlib `xml.etree.ElementTree` still expands internal entity references during parsing, so a maliciously crafted Office document or compromised/MITM-tampered API response can trigger a **billion-laughs / quadratic-blowup DoS** even though external-entity references have been disabled by default since Python 3.7.1.

`defusedxml` is already a runtime dependency — `scientific-skills/{docx,pptx,xlsx}/scripts/office/helpers/simplify_redlines.py` already imports `defusedxml.minidom` at module scope. This PR consistently uses `defusedxml.ElementTree` across the remaining parse sites.

## Impact

- Loading a malicious `.docx` / `.pptx` / `.xlsx` through `scripts/office/unpack.py` or `scripts/office/validate.py` exhausts CPU/memory before any content extraction happens.
- A compromised PubMed/arXiv/CrossRef/LabArchives/Treasury server (or an MITM in front of one) can DoS any skill that calls into the corresponding script.

Not RCE / auth-bypass — the stdlib parser does not resolve external entities post-3.7.1 — but billion-laughs is in-scope.

## Location

11 Python files + 3 doc-snippets (full list in the commit message). Representative entry points:

- `scientific-skills/citation-management/scripts/extract_metadata.py:14`
- `scientific-skills/citation-management/scripts/search_pubmed.py:13`
- `scientific-skills/docx/scripts/office/validators/redlining.py:32, 77`
- `scientific-skills/docx/scripts/office/helpers/simplify_redlines.py:13`
- `scientific-skills/labarchive-integration/scripts/entry_operations.py:47, 98`

(pptx/ and xlsx/ office trees are byte-identical to docx/ — both files have the same MD5.)

## Fix

`import xml.etree.ElementTree as ET` → `import defusedxml.ElementTree as ET`. `defusedxml.ElementTree` is a drop-in for `ET.parse`, `ET.fromstring`, and `ET.ParseError`.

It does **not** re-export `Element`. Two files (`citation-management/scripts/extract_metadata.py` line 403, `search_pubmed.py` line 154) use `ET.Element` as a type annotation, so `Element` is imported directly from `xml.etree.ElementTree` with a `# nosemgrep: use-defused-xml` comment explaining that `Element` is a data class, not a parser.

Documentation snippets that show the import pattern as user guidance were updated to match (`labarchive-integration/SKILL.md`, `references/authentication_guide.md`, `usfiscaldata/references/response-format.md`) so people copy-pasting from the docs land on the safe pattern.

## Detected by

Aeon + semgrep (`p/security-audit` rules `use-defused-xml` and `use-defused-xml-parse`).

- Severity: medium (DoS only, not RCE)
- CWE-776 (XML Entity Expansion) / CWE-611 (XXE — mitigated by stdlib defaults but defense-in-depth)

## Verification

- Re-ran semgrep after the change: **31 → 0** `use-defused-xml` findings.
- All 11 modified Python files compile (`python3 -c 'import ast; ast.parse(open(p).read())'`).
- `citation-management/extract_metadata.py` and `search_pubmed.py` import end-to-end (verified the `Element` type-annotation import resolves).
- No project test suite covers these specific parsers; the repo's own `scan_skills.py` security scanner should re-classify these files from `🔴 CRITICAL` / `🟠 HIGH` once defused, but I haven't re-run that pipeline (it needs an LLM API key).

## Related findings (out of scope for this PR, called out for visibility)

- `scan_skills.py` / `scan_pr_skills.py` resolves `cisco-ai-skill-scanner` → `litellm@1.83.0`, which has GHSA-r75f-5x8p-qvmc (CRITICAL, SQL injection in Proxy API key verification) and three HIGH advisories. Those are all LiteLLM **Proxy** vectors and this repo only uses the LiteLLM SDK to call upstream LLMs, so it doesn't appear exploitable in-tree — but a periodic `uv lock --upgrade` would close them.
- 20 semgrep `dangerous-subprocess-use-tainted-env-args` hits across `generate_schematic.py` / `generate_infographic.py` / `generate_slide_image.py` look like false positives: `cmd` is passed as a list (no shell) and `env` is `os.environ.copy()` with an additive `OPENROUTER_API_KEY`. Happy to draft a separate PR if you'd prefer to suppress them at the rule level.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).