### PR TITLE
fix: quote research-lookup description to restore valid YAML frontmatter

### DIFF
--- a/scientific-skills/research-lookup/SKILL.md
+++ b/scientific-skills/research-lookup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-lookup
-description: Look up current research information using parallel-cli search (primary, fast web search), the Parallel Chat API (deep research), or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information. Note: query text is transmitted to api.parallel.ai (PARALLEL_API_KEY) and, for academic searches, to openrouter.ai (OPENROUTER_API_KEY).
+description: 'Look up current research information using parallel-cli search (primary, fast web search), the Parallel Chat API (deep research), or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information. Note: query text is transmitted to api.parallel.ai (PARALLEL_API_KEY) and, for academic searches, to openrouter.ai (OPENROUTER_API_KEY).'
 allowed-tools: Read Write Edit Bash
 license: MIT license
 compatibility: parallel-cli required (primary); PARALLEL_API_KEY and OPENROUTER_API_KEY optional for deep/academic backends


### PR DESCRIPTION
## Summary

Restores the `research-lookup` skill so Codex and other YAML loaders can parse its frontmatter again. One-character class fix: wrap the `description:` value in single quotes.

## Why this matters

@lyr1cs reported in #159 that loading the skill emits `mapping values are not allowed in this context at line 2 column 343`, and Codex silently skips the skill. Root cause traced in the issue: PR #149 appended a `Note: query text is transmitted to api.parallel.ai ...` clause to the unquoted description scalar, so the `:` after `Note` parsed as a new mapping key and broke the entire frontmatter block.

The fix preserves the PARALLEL_API_KEY / OPENROUTER_API_KEY disclosure clause that PR #149 introduced. No description text changes.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('scientific-skills/research-lookup/SKILL.md').read().split('---',2)[1])"` now returns a dict with `name: research-lookup` and the full disclosure-bearing description.
- `grep -c "^description: '" scientific-skills/research-lookup/SKILL.md` returns 1.
- Diff is exactly 1 line; no other content touched.

The reporter also suggested a CI YAML-lint step to prevent regressions of this class. Left out of this PR to keep scope tight, but happy to follow up if useful.

Fixes #159
