### PR TITLE
autodev: pptx-posters: Quality Checklist missing Step 1 and Step 2a

### DIFF
--- a/skills/pptx-posters/SKILL.md
+++ b/skills/pptx-posters/SKILL.md
@@ -338,7 +338,7 @@ body {
 - ❌ "Timeline 2015-2024 annual" → "ONLY 3 key years"
 - ❌ "Compare 6 methods" → "ONLY 2: ours vs best"
 
-### Step 2b: Post-Generation Review (MANDATORY)
+### Step 1: Post-Generation Review (MANDATORY)
 
 **For EACH generated figure at 25% zoom:**
 
@@ -357,7 +357,7 @@ body {
 - [ ] Complex multi-stage → SPLIT into 2-3 graphics
 - [ ] Multiple cases cramped → SPLIT into separate graphics
 
-### After Export
+### Step 2: After Export (MANDATORY)
 
 - [ ] NO content cut off at ANY of the 4 edges (check carefully)
 - [ ] All images display correctly
@@ -411,4 +411,3 @@ Available in `references/` directory:
 - `poster_content_guide.md`: Content organization and writing guidelines
 - `poster_design_principles.md`: Typography, color theory, and visual hierarchy
 - `poster_layout_design.md`: Layout principles and grid systems
-


### PR DESCRIPTION
Resolves #194

### Overview

This PR resolves an issue in the `pptx-posters` Quality Checklist where the step sequence was non-contiguous. Previously, the checklist jumped from `Step 0` to `Step 2b`, leaving `Step 1` and `Step 2a` missing. 

To address this cleanly without adding unnecessary filler content, the existing steps have been renumbered to form a logical, contiguous sequence: **Step 0**, **Step 1**, and **Step 2**.

### Key Changes

* **`skills/pptx-posters/SKILL.md`**
  * Retained `### Step 0: Pre-Generation Review (MANDATORY)`.
  * Renamed `### Step 2b: Post-Generation Review (MANDATORY)` to `### Step 1: Post-Generation Review (MANDATORY)`.
  * Renamed `### After Export` to `### Step 2: After Export (MANDATORY)`.

### Verification

* Verified that the Quality Checklist sequence is now contiguous and logically structured.
* Confirmed that all unit tests have passed successfully.

---
*Opened autonomously by [autodev](https://github.com/arman1o1/autodev)*