### PR TITLE
Add Atlas Cloud provider to generate-image skill

### DIFF
--- a/skills/generate-image/SKILL.md
+++ b/skills/generate-image/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: generate-image
-description: Generate or edit images using AI models (FLUX, Nano Banana 2). Use for general-purpose image generation including photos, illustrations, artwork, visual assets, concept art, and any image that is not a technical diagram or schematic. For flowcharts, circuits, pathways, and technical diagrams, use the scientific-schematics skill instead.
+description: Generate or edit images using AI models (FLUX, Nano Banana 2) through OpenRouter or Atlas Cloud. Use for general-purpose image generation including photos, illustrations, artwork, visual assets, concept art, and any image that is not a technical diagram or schematic. For flowcharts, circuits, pathways, and technical diagrams, use the scientific-schematics skill instead.
 license: MIT license
-compatibility: Requires an OpenRouter API key
+compatibility: Requires an OpenRouter API key, or an Atlas Cloud API key when using --provider atlascloud
 metadata: {"version": "1.0", "skill-author": "K-Dense Inc."}
 ---
 
 # Generate Image
 
-Generate and edit high-quality images using OpenRouter's image generation models including FLUX.2 Pro and Gemini 3.1 Flash Image Preview.
+Generate and edit high-quality images using OpenRouter's image generation models including FLUX.2 Pro and Gemini 3.1 Flash Image Preview, or Atlas Cloud's Nano Banana 2 media models.
 
 ## When to Use This Skill
 
@@ -38,13 +38,19 @@ python scripts/generate_image.py "A beautiful sunset over mountains"
 
 # Edit an existing image
 python scripts/generate_image.py "Make the sky purple" --input photo.jpg
+
+# Generate through Atlas Cloud
+python scripts/generate_image.py "A beautiful sunset over mountains" --provider atlascloud
+
+# Edit through Atlas Cloud
+python scripts/generate_image.py "Make the sky purple" --provider atlascloud --input photo.jpg
 ```
 
 This generates/edits an image and saves it as `generated_image.png` in the current directory.
 
 ## API Key Setup
 
-**CRITICAL**: The script requires an OpenRouter API key. Before running, check if the user has configured their API key:
+**CRITICAL**: The default OpenRouter provider requires an OpenRouter API key. Before running, check if the user has configured their API key:
 
 1. Look for a `.env` file in the project directory or parent directories
 2. Check for `OPENROUTER_API_KEY=<key>` in the `.env` file
@@ -54,6 +60,16 @@ This generates/edits an image and saves it as `generated_image.png` in the curre
    - Get an API key from: https://openrouter.ai/keys
 
 The script will automatically detect the `.env` file and provide clear error messages if the API key is missing.
+
+For Atlas Cloud, set either:
+
+```bash
+export ATLASCLOUD_API_KEY=your-api-key-here
+# or
+export ATLAS_CLOUD_API_KEY=your-api-key-here
+```
+
+Then add `--provider atlascloud`. The script also checks `.env` files for these variables.
 
 ## Model Selection
 
@@ -65,6 +81,10 @@ The script will automatically detect the `.env` file and provide clear error mes
 
 **Generation only**:
 - `black-forest-labs/flux.2-flex` - Fast and cheap, but not as high quality as pro
+
+**Atlas Cloud models**:
+- `google/nano-banana-2/text-to-image` - Default for `--provider atlascloud` generation
+- `google/nano-banana-2/edit` - Default for `--provider atlascloud --input` editing
 
 Select based on:
 - **Quality**: Use gemini-3.1-flash-image-preview or flux.2-pro
@@ -83,6 +103,11 @@ python scripts/generate_image.py "Your prompt here"
 python scripts/generate_image.py "A cat in space" --model "black-forest-labs/flux.2-pro"
 ```
 
+### Use Atlas Cloud
+```bash
+python scripts/generate_image.py "A cat in space" --provider atlascloud --aspect-ratio 16:9 --resolution 2k
+```
+
 ### Custom output path
 ```bash
 python scripts/generate_image.py "Abstract art" --output artwork.png
@@ -91,6 +116,11 @@ python scripts/generate_image.py "Abstract art" --output artwork.png
 ### Edit an existing image
 ```bash
 python scripts/generate_image.py "Make the background blue" --input photo.jpg
+```
+
+### Edit with Atlas Cloud
+```bash
+python scripts/generate_image.py "Make the background blue" --provider atlascloud --input photo.jpg --output edited.png
 ```
 
 ### Edit with a specific model
@@ -114,9 +144,15 @@ python scripts/generate_image.py "Image 2 description" --output image2.png
 
 - `prompt` (required): Text description of the image to generate, or editing instructions
 - `--input` or `-i`: Input image path for editing (enables edit mode)
-- `--model` or `-m`: OpenRouter model ID (default: google/gemini-3.1-flash-image-preview)
+- `--provider`: `openrouter` or `atlascloud` (default: openrouter)
+- `--model` or `-m`: Provider model ID (default: google/gemini-3.1-flash-image-preview; maps to Nano Banana 2 defaults for Atlas Cloud)
 - `--output` or `-o`: Output file path (default: generated_image.png)
-- `--api-key`: OpenRouter API key (overrides .env file)
+- `--api-key`: Provider API key (overrides environment or .env file)
+- `--aspect-ratio`: Atlas Cloud aspect ratio, such as `1:1`, `16:9`, or `9:16`
+- `--resolution`: Atlas Cloud resolution: `1k`, `2k`, or `4k`
+- `--output-format`: Atlas Cloud output format: `default`, `png`, or `jpeg`
+- `--poll-interval`: Seconds between Atlas Cloud prediction polls
+- `--timeout`: Maximum seconds to wait for Atlas Cloud completion
 
 ## Example Use Cases
 
@@ -161,8 +197,10 @@ If the script fails, read the error message and address the issue before retryin
 
 - Images are returned as base64-encoded data URLs and automatically saved as PNG files
 - The script supports both `images` and `content` response formats from different OpenRouter models
+- Atlas Cloud generation is asynchronous: the script submits a task, polls the prediction endpoint, and downloads the first output
 - Generation time varies by model (typically 5-30 seconds)
 - For image editing, the input image is encoded as base64 and sent to the model
+- For Atlas Cloud editing, the input image is uploaded temporarily through Atlas Cloud's media upload endpoint
 - Supported input image formats: PNG, JPEG, GIF, WebP
 - Check OpenRouter pricing for cost information: https://openrouter.ai/models
 
@@ -179,4 +217,3 @@ If the script fails, read the error message and address the issue before retryin
 - **generate-image**: Use for photos, illustrations, artwork, visual concepts
 - **scientific-slides**: Combine with generate-image for visually rich presentations
 - **latex-posters**: Use generate-image for poster visuals and hero images
-

--- a/skills/generate-image/scripts/generate_image.py
+++ b/skills/generate-image/scripts/generate_image.py
@@ -15,12 +15,20 @@ import sys
 import json
 import base64
 import argparse
+import os
+import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 
-def check_env_file() -> Optional[str]:
-    """Check if .env file exists and contains OPENROUTER_API_KEY."""
+ATLAS_CLOUD_API_BASE = "https://api.atlascloud.ai/api/v1"
+ATLAS_CLOUD_GENERATE_MODEL = "google/nano-banana-2/text-to-image"
+ATLAS_CLOUD_EDIT_MODEL = "google/nano-banana-2/edit"
+OPENROUTER_DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview"
+
+
+def check_env_file(var_names: tuple[str, ...] = ("OPENROUTER_API_KEY",)) -> Optional[str]:
+    """Check if .env file exists and contains one of the requested API keys."""
     # Look for .env in current directory and parent directories
     current_dir = Path.cwd()
     for parent in [current_dir] + list(current_dir.parents):
@@ -28,11 +36,25 @@ def check_env_file() -> Optional[str]:
         if env_file.exists():
             with open(env_file, 'r') as f:
                 for line in f:
-                    if line.startswith('OPENROUTER_API_KEY='):
-                        api_key = line.split('=', 1)[1].strip().strip('"').strip("'")
-                        if api_key:
-                            return api_key
+                    for var_name in var_names:
+                        if line.startswith(f'{var_name}='):
+                            api_key = line.split('=', 1)[1].strip().strip('"').strip("'")
+                            if api_key:
+                                return api_key
     return None
+
+
+def resolve_api_key(provider: str, explicit_key: Optional[str]) -> Optional[str]:
+    """Resolve the API key for the selected provider."""
+    if explicit_key:
+        return explicit_key
+    if provider == "atlascloud":
+        return (
+            os.getenv("ATLASCLOUD_API_KEY")
+            or os.getenv("ATLAS_CLOUD_API_KEY")
+            or check_env_file(("ATLASCLOUD_API_KEY", "ATLAS_CLOUD_API_KEY"))
+        )
+    return os.getenv("OPENROUTER_API_KEY") or check_env_file(("OPENROUTER_API_KEY",))
 
 
 def load_image_as_base64(image_path: str) -> str:
@@ -72,22 +94,205 @@ def save_base64_image(base64_data: str, output_path: str) -> None:
         f.write(image_data)
 
 
+def save_image_output(output: Any, output_path: str) -> None:
+    """Save an image output returned as a URL, data URL, or base64 string."""
+    try:
+        import requests
+    except ImportError:
+        print("Error: 'requests' library not found. Install with: pip install requests")
+        sys.exit(1)
+
+    if isinstance(output, dict):
+        for key in ("url", "download_url", "image_url"):
+            if output.get(key):
+                return save_image_output(output[key], output_path)
+        for key in ("b64_json", "base64", "data"):
+            if output.get(key):
+                return save_image_output(output[key], output_path)
+
+    if not isinstance(output, str):
+        print(f"⚠️ Unexpected image output format: {output}")
+        sys.exit(1)
+
+    if output.startswith(("http://", "https://")):
+        response = requests.get(output, timeout=300)
+        if response.status_code != 200:
+            print(f"❌ Failed to download generated image ({response.status_code}): {response.text[:300]}")
+            sys.exit(1)
+        with open(output_path, 'wb') as f:
+            f.write(response.content)
+        return
+
+    save_base64_image(output, output_path)
+
+
+def upload_atlas_image(api_key: str, image_path: str) -> str:
+    """Upload a local image to Atlas Cloud and return the temporary media URL."""
+    try:
+        import requests
+    except ImportError:
+        print("Error: 'requests' library not found. Install with: pip install requests")
+        sys.exit(1)
+
+    path = Path(image_path)
+    if not path.exists():
+        print(f"❌ Error: Image file not found: {image_path}")
+        sys.exit(1)
+
+    with open(path, "rb") as f:
+        response = requests.post(
+            f"{ATLAS_CLOUD_API_BASE}/model/uploadMedia",
+            headers={"Authorization": f"Bearer {api_key}"},
+            files={"file": (path.name, f)},
+            timeout=120,
+        )
+
+    if response.status_code != 200:
+        print(f"❌ Atlas Cloud upload error ({response.status_code}): {response.text}")
+        sys.exit(1)
+
+    payload = response.json()
+    data = payload.get("data", payload)
+    media_url = data.get("download_url") or data.get("url")
+    if not media_url:
+        print(f"❌ Atlas Cloud upload response did not include a media URL: {payload}")
+        sys.exit(1)
+    return media_url
+
+
+def atlas_prediction_payload(response_json: dict[str, Any]) -> dict[str, Any]:
+    data = response_json.get("data")
+    return data if isinstance(data, dict) else response_json
+
+
+def atlas_prediction_outputs(payload: dict[str, Any]) -> list[Any]:
+    for key in ("outputs", "output", "result", "images", "urls"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return value
+        if value:
+            return [value]
+    return []
+
+
+def generate_image_atlascloud(
+    prompt: str,
+    model: str,
+    output_path: str,
+    api_key: str,
+    input_image: Optional[str] = None,
+    aspect_ratio: str = "1:1",
+    resolution: str = "1k",
+    output_format: str = "png",
+    poll_interval: float = 3.0,
+    timeout_seconds: float = 300.0,
+) -> dict:
+    """Generate or edit an image using Atlas Cloud's async Media API."""
+    try:
+        import requests
+    except ImportError:
+        print("Error: 'requests' library not found. Install with: pip install requests")
+        sys.exit(1)
+
+    is_editing = input_image is not None
+    if model == OPENROUTER_DEFAULT_MODEL:
+        model = ATLAS_CLOUD_EDIT_MODEL if is_editing else ATLAS_CLOUD_GENERATE_MODEL
+
+    if is_editing:
+        print(f"✏️ Editing image with Atlas Cloud model: {model}")
+        print(f"📷 Input image: {input_image}")
+        image_url = upload_atlas_image(api_key, input_image)
+    else:
+        print(f"🎨 Generating image with Atlas Cloud model: {model}")
+        image_url = None
+    print(f"📝 Prompt: {prompt}")
+
+    body: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "aspect_ratio": aspect_ratio,
+        "resolution": resolution,
+        "output_format": output_format,
+    }
+    if image_url:
+        body["images"] = [image_url]
+
+    response = requests.post(
+        f"{ATLAS_CLOUD_API_BASE}/model/generateImage",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json=body,
+        timeout=120,
+    )
+
+    if response.status_code != 200:
+        print(f"❌ Atlas Cloud API Error ({response.status_code}): {response.text}")
+        sys.exit(1)
+
+    submitted = response.json()
+    prediction = atlas_prediction_payload(submitted)
+    prediction_id = prediction.get("id") or prediction.get("prediction_id")
+    if not prediction_id:
+        print(f"❌ Atlas Cloud response did not include a prediction ID: {submitted}")
+        sys.exit(1)
+
+    print(f"⏳ Atlas Cloud prediction: {prediction_id}")
+    deadline = time.monotonic() + max(1.0, timeout_seconds)
+    interval = max(1.0, poll_interval)
+    while time.monotonic() < deadline:
+        poll_response = requests.get(
+            f"{ATLAS_CLOUD_API_BASE}/model/prediction/{prediction_id}",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=60,
+        )
+        if poll_response.status_code != 200:
+            print(f"❌ Atlas Cloud polling error ({poll_response.status_code}): {poll_response.text}")
+            sys.exit(1)
+
+        current = atlas_prediction_payload(poll_response.json())
+        status = str(current.get("status") or "").lower()
+        if status in {"completed", "succeeded", "success"}:
+            outputs = atlas_prediction_outputs(current)
+            if not outputs:
+                print(f"❌ Atlas Cloud prediction completed without outputs: {current}")
+                sys.exit(1)
+            save_image_output(outputs[0], output_path)
+            print(f"✅ Image saved to: {output_path}")
+            return current
+        if status in {"failed", "error", "canceled", "cancelled"}:
+            print(f"❌ Atlas Cloud prediction failed: {json.dumps(current, indent=2)}")
+            sys.exit(1)
+        time.sleep(interval)
+
+    print(f"❌ Atlas Cloud prediction timed out after {timeout_seconds:g}s: {prediction_id}")
+    sys.exit(1)
+
+
 def generate_image(
     prompt: str,
-    model: str = "google/gemini-3.1-flash-image-preview",
+    model: str = OPENROUTER_DEFAULT_MODEL,
     output_path: str = "generated_image.png",
     api_key: Optional[str] = None,
-    input_image: Optional[str] = None
+    input_image: Optional[str] = None,
+    provider: str = "openrouter",
+    aspect_ratio: str = "1:1",
+    resolution: str = "1k",
+    output_format: str = "png",
+    poll_interval: float = 3.0,
+    timeout_seconds: float = 300.0,
 ) -> dict:
     """
-    Generate or edit an image using OpenRouter API.
+    Generate or edit an image using OpenRouter or Atlas Cloud.
 
     Args:
         prompt: Text description of the image to generate, or editing instructions
         model: OpenRouter model ID (default: google/gemini-3.1-flash-image-preview)
         output_path: Path to save the generated image
-        api_key: OpenRouter API key (will check .env if not provided)
+        api_key: API key (will check .env if not provided)
         input_image: Path to an input image for editing (optional)
+        provider: "openrouter" or "atlascloud"
 
     Returns:
         dict: Response from OpenRouter API
@@ -98,18 +303,36 @@ def generate_image(
         print("Error: 'requests' library not found. Install with: pip install requests")
         sys.exit(1)
 
-    # Check for API key
-    if not api_key:
-        api_key = check_env_file()
+    api_key = resolve_api_key(provider, api_key)
 
     if not api_key:
-        print("❌ Error: OPENROUTER_API_KEY not found!")
-        print("\nPlease create a .env file in your project directory with:")
-        print("OPENROUTER_API_KEY=your-api-key-here")
-        print("\nOr set the environment variable:")
-        print("export OPENROUTER_API_KEY=your-api-key-here")
-        print("\nGet your API key from: https://openrouter.ai/keys")
+        if provider == "atlascloud":
+            print("❌ Error: ATLASCLOUD_API_KEY or ATLAS_CLOUD_API_KEY not found!")
+            print("\nSet it with:")
+            print("export ATLASCLOUD_API_KEY=your-api-key-here")
+            print("\nGet your API key from: https://www.atlascloud.ai/console/api-keys")
+        else:
+            print("❌ Error: OPENROUTER_API_KEY not found!")
+            print("\nPlease create a .env file in your project directory with:")
+            print("OPENROUTER_API_KEY=your-api-key-here")
+            print("\nOr set the environment variable:")
+            print("export OPENROUTER_API_KEY=your-api-key-here")
+            print("\nGet your API key from: https://openrouter.ai/keys")
         sys.exit(1)
+
+    if provider == "atlascloud":
+        return generate_image_atlascloud(
+            prompt=prompt,
+            model=model,
+            output_path=output_path,
+            api_key=api_key,
+            input_image=input_image,
+            aspect_ratio=aspect_ratio,
+            resolution=resolution,
+            output_format=output_format,
+            poll_interval=poll_interval,
+            timeout_seconds=timeout_seconds,
+        )
 
     # Determine if this is generation or editing
     is_editing = input_image is not None
@@ -208,12 +431,18 @@ def generate_image(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate or edit images using OpenRouter API",
+        description="Generate or edit images using OpenRouter or Atlas Cloud",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
   # Generate with default model (Gemini 3.1 Flash Image Preview)
   python generate_image.py "A beautiful sunset over mountains"
+
+  # Generate with Atlas Cloud Nano Banana 2
+  python generate_image.py "A beautiful sunset over mountains" --provider atlascloud
+
+  # Edit an image with Atlas Cloud Nano Banana 2
+  python generate_image.py "Make the sky purple" --provider atlascloud --input photo.jpg --output edited.png
 
   # Use a specific model
   python generate_image.py "A cat in space" --model "black-forest-labs/flux.2-pro"
@@ -231,6 +460,10 @@ Popular image models:
   - google/gemini-3.1-flash-image-preview (default, high quality, generation + editing)
   - black-forest-labs/flux.2-pro (fast, high quality, generation + editing)
   - black-forest-labs/flux.2-flex (development version)
+
+Atlas Cloud default models:
+  - google/nano-banana-2/text-to-image (generation)
+  - google/nano-banana-2/edit (editing)
         """
     )
 
@@ -241,10 +474,20 @@ Popular image models:
     )
 
     parser.add_argument(
+        "--provider",
+        choices=["openrouter", "atlascloud"],
+        default="openrouter",
+        help="Image provider (default: openrouter)"
+    )
+
+    parser.add_argument(
         "--model", "-m",
         type=str,
-        default="google/gemini-3.1-flash-image-preview",
-        help="OpenRouter model ID (default: google/gemini-3.1-flash-image-preview)"
+        default=OPENROUTER_DEFAULT_MODEL,
+        help=(
+            "Model ID. Defaults to OpenRouter's Gemini image model; with "
+            "--provider atlascloud, this default maps to Nano Banana 2 generation/edit models."
+        )
     )
 
     parser.add_argument(
@@ -263,7 +506,42 @@ Popular image models:
     parser.add_argument(
         "--api-key",
         type=str,
-        help="OpenRouter API key (will check .env if not provided)"
+        help="Provider API key (will check environment and .env if not provided)"
+    )
+
+    parser.add_argument(
+        "--aspect-ratio",
+        choices=["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        default="1:1",
+        help="Atlas Cloud aspect ratio (default: 1:1)"
+    )
+
+    parser.add_argument(
+        "--resolution",
+        choices=["1k", "2k", "4k"],
+        default="1k",
+        help="Atlas Cloud output resolution (default: 1k)"
+    )
+
+    parser.add_argument(
+        "--output-format",
+        choices=["default", "png", "jpeg"],
+        default="png",
+        help="Atlas Cloud output format (default: png)"
+    )
+
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=3.0,
+        help="Seconds between Atlas Cloud prediction polls (default: 3)"
+    )
+
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="Maximum seconds to wait for Atlas Cloud prediction completion (default: 300)"
     )
 
     args = parser.parse_args()
@@ -273,7 +551,13 @@ Popular image models:
         model=args.model,
         output_path=args.output,
         api_key=args.api_key,
-        input_image=args.input
+        input_image=args.input,
+        provider=args.provider,
+        aspect_ratio=args.aspect_ratio,
+        resolution=args.resolution,
+        output_format=args.output_format,
+        poll_interval=args.poll_interval,
+        timeout_seconds=args.timeout,
     )
 
 


### PR DESCRIPTION
## Summary
- add optional `--provider atlascloud` support to `skills/generate-image/scripts/generate_image.py`
- support Atlas Cloud Nano Banana 2 text-to-image and edit via upload, async generation, prediction polling, and output download
- document Atlas Cloud API key setup, default models, and provider-specific flags in the generate-image skill

## Validation
- verified live Atlas Cloud models `google/nano-banana-2/text-to-image` and `google/nano-banana-2/edit` with `display_console=true`
- verified their live schemas before mapping `prompt`, `images`, `aspect_ratio`, `resolution`, and `output_format`

## Tests
- `python3 -m py_compile skills/generate-image/scripts/generate_image.py`
- `python3 skills/generate-image/scripts/generate_image.py --help`
- `env -u ATLASCLOUD_API_KEY -u ATLAS_CLOUD_API_KEY python3 skills/generate-image/scripts/generate_image.py 'test prompt' --provider atlascloud --output /tmp/atlas-test.png`
- `env -u OPENROUTER_API_KEY python3 skills/generate-image/scripts/generate_image.py 'test prompt' --output /tmp/openrouter-test.png`
- `python3 skills/generate-image/scripts/generate_image.py 'A simple scientific icon: blue molecule on a white background, clean vector style' --provider atlascloud --output /tmp/atlas-generate-image-smoke.png --resolution 1k --aspect-ratio 1:1 --timeout 180`
- `python3 skills/generate-image/scripts/generate_image.py 'Change the molecule color to green while keeping the white background and clean vector style' --provider atlascloud --input /tmp/atlas-generate-image-smoke.png --output /tmp/atlas-generate-image-edit-smoke.png --resolution 1k --aspect-ratio 1:1 --timeout 180`
