### PR TITLE
fix(rdkit): correct FractionCsp3 call and MolToSmarts parameter name

### DIFF
--- a/skills/rdkit/references/api_reference.md
+++ b/skills/rdkit/references/api_reference.md
@@ -24,7 +24,7 @@ The fundamental module for working with molecules.
 **Writing Molecules:**
 
 - `Chem.MolToSmiles(mol, isomericSmiles=True, canonical=True)` - Convert to SMILES
-- `Chem.MolToSmarts(mol, isomericSmarts=False)` - Convert to SMARTS
+- `Chem.MolToSmarts(mol, isomericSmiles=False)` - Convert to SMARTS
 - `Chem.MolToMolBlock(mol, includeStereo=True, confId=-1)` - Convert to MOL block
 - `Chem.MolToMolFile(mol, filename, includeStereo=True, confId=-1)` - Write MOL file
 - `Chem.MolToPDBBlock(mol, confId=-1)` - Convert to PDB block

--- a/skills/rdkit/scripts/molecular_properties.py
+++ b/skills/rdkit/scripts/molecular_properties.py
@@ -62,7 +62,7 @@ def calculate_properties(mol):
 
         # Flexibility
         'Rotatable_Bonds': Descriptors.NumRotatableBonds(mol),
-        'Fraction_Csp3': Descriptors.FractionCsp3(mol),
+        'Fraction_Csp3': Lipinski.FractionCSP3(mol),
 
         # Complexity
         'BertzCT': Descriptors.BertzCT(mol),


### PR DESCRIPTION
Lands the valid parts of #97 and #95, which target the pre-rename `scientific-skills/` path and cannot be merged directly.

## Changes

- `skills/rdkit/scripts/molecular_properties.py` — `Descriptors.FractionCsp3` → `Lipinski.FractionCSP3`
- `skills/rdkit/references/api_reference.md` — `isomericSmarts` → `isomericSmiles`

## Verification

Against RDKit 2026.03.3:

```
Descriptors.FractionCsp3(m)     FAIL -> AttributeError: module 'rdkit.Chem.Descriptors' has no attribute 'FractionCsp3'
Lipinski.FractionCSP3(m)        OK   -> 0.1111111111111111
Chem.MolToSmarts(m, isomericSmarts=False)  FAIL -> ArgumentError
Chem.MolToSmarts(m, isomericSmiles=False)  OK
```

This was a hard crash: `molecular_properties.py` failed for every input molecule on `main`. The script now runs end-to-end:

```
$ python3 skills/rdkit/scripts/molecular_properties.py "CC(=O)Oc1ccccc1C(=O)O"
  Fraction Csp3:       0.111
  QED Score:           0.550
  Lipinski Pass:       Yes
```

## Known remaining inaccuracy

The API reference documents `MolToSmarts(mol, isomericSmiles=False)`, but RDKit's actual default is `True`:

```
MolToSmarts( (Mol)mol [, (bool)isomericSmiles=True [, (int)rootedAtAtom=-1]]) -> str
```

Left as-is to keep this change scoped to the contributed fixes. Worth a follow-up.

Credit to @jiaodu1307.