### PR TITLE
fix(imaging-data-commons): correct 'questons' typo

### DIFF
--- a/skills/imaging-data-commons/SKILL.md
+++ b/skills/imaging-data-commons/SKILL.md
@@ -758,7 +758,7 @@ See `references/use_cases.md` for complete end-to-end workflow examples includin
 - **Estimate size first** - Check collection size before downloading - some collection sizes are in terabytes!
 - **Save manifests** - Always save query results with Series UIDs for reproducibility and data provenance
 - **Read documentation** - IDC data structure and metadata fields are documented at https://learn.canceridc.dev/
-- **Use IDC forum** - Search for questons/answers and ask your questions to the IDC maintainers and users at https://discourse.canceridc.dev/
+- **Use IDC forum** - Search for questions/answers and ask your questions to the IDC maintainers and users at https://discourse.canceridc.dev/
 
 ## Troubleshooting
 


### PR DESCRIPTION
One-word typo fix at `skills/imaging-data-commons/SKILL.md:761`: `questons` → `questions`.

Surfaced by the codespell config proposed in #123. That PR was closed — on a clean checkout the config produced 52 hits with only this one genuine, and the ignore list required to make it pass was judged too high-maintenance for a repo this heavy in domain acronyms. The typo itself is real, so landing it here with credit to @yarikoptic.