### PR TITLE
Add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug report
+description: A skill or repository tool behaves incorrectly — wrong output, broken script, failing install, or instructions an agent cannot follow.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this. Please do **not** use this form for security
+        vulnerabilities — use [private vulnerability reporting](https://github.com/K-Dense-AI/scientific-agent-skills/security/advisories/new)
+        instead, as described in [SECURITY.md](https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/SECURITY.md).
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the repository is affected?
+      options:
+        - A skill under skills/
+        - Repository tooling (scan_skills.py, tests, CI workflows)
+        - Documentation (README, CONTRIBUTING, AGENTS)
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: skill
+    attributes:
+      label: Skill name
+      description: The skill directory name, exactly as it appears under `skills/`. Leave blank if this is not skill-specific.
+      placeholder: scanpy
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did the skill or tool actually do?
+      placeholder: The skill's example call to sc.pp.neighbors() fails with a TypeError.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The smallest sequence that triggers it. Include the prompt you gave the agent, if relevant.
+      placeholder: |
+        1. Load the `scanpy` skill in Claude Code
+        2. Ask: "cluster my AnnData object"
+        3. Run the code the agent produces
+        4. See the error below
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output
+      description: Paste the traceback or scanner output. This is rendered as a code block, so no backticks are needed.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Skill behavior varies by agent host and model, so please tell us where you saw this.
+      value: |
+        - Agent host (Claude Code, Cursor, Codex, other):
+        - Model:
+        - Repository version or commit:
+        - Python version:
+        - Operating system:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability. (Those go through private reporting.)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/K-Dense-AI/scientific-agent-skills/security/advisories/new
+    about: Do not open a public issue. Use private vulnerability reporting so the report stays confidential until a fix ships. See SECURITY.md.
+  - name: Contributing guide
+    url: https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/CONTRIBUTING.md
+    about: Read this before proposing a skill change — skill format, validation, tests, and the pull request checklist.
+  - name: Agent Skills specification
+    url: https://agentskills.io/specification
+    about: The open specification every skill in this repository follows.
+  - name: K-Dense documentation
+    url: https://k-dense.ai
+    about: Product documentation and general questions about K-Dense.

--- a/.github/ISSUE_TEMPLATE/new_skill_request.yml
+++ b/.github/ISSUE_TEMPLATE/new_skill_request.yml
@@ -1,0 +1,90 @@
+name: New skill request
+description: Propose a skill for a scientific package, database, platform, workflow, or research method that the library does not cover yet.
+title: "[New skill]: "
+labels: ["enhancement", "skill-request", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check the [skill list in the README](https://github.com/K-Dense-AI/scientific-agent-skills#readme)
+        first — the library already ships a large number of skills. If you plan to
+        write this skill yourself, [CONTRIBUTING.md](https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/CONTRIBUTING.md)
+        has the required format and validation steps.
+
+  - type: input
+    id: name
+    attributes:
+      label: Proposed skill name
+      description: Lowercase letters, numbers, and single hyphens only — this becomes the directory name under `skills/`.
+      placeholder: alphafold-db
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Scientific package or library
+        - Database or public data resource
+        - Platform, service, or API
+        - Analysis workflow or research method
+        - Laboratory instrument or hardware
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What the skill would do
+      description: What should an agent be able to accomplish with it that it cannot do reliably today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: when
+    attributes:
+      label: When an agent should use it
+      description: The situations that should trigger this skill. This becomes the "when to use" half of the skill description.
+    validations:
+      required: true
+
+  - type: textarea
+    id: docs
+    attributes:
+      label: Official documentation and sources
+      description: Links to the package docs, API reference, publication, or database homepage a skill author would need.
+      placeholder: |
+        - Docs: https://...
+        - API reference: https://...
+        - Paper: https://doi.org/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: credentials
+    attributes:
+      label: Credentials or access requirements
+      description: Does it need an API key, licence, registration, or institutional access? Name the environment variables if you know them.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you like to write this skill?
+      options:
+        - "Yes — I plan to open a pull request"
+        - "Maybe, with some guidance"
+        - "No, I am requesting it"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked the README skill list and this skill does not already exist.
+          required: true

--- a/.github/ISSUE_TEMPLATE/skill_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/skill_improvement.yml
@@ -1,0 +1,68 @@
+name: Improve an existing skill
+description: An existing skill is outdated, unclear, or incomplete — stale API, missing workflow, weak examples, or a description that triggers at the wrong time.
+title: "[Improve]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: input
+    id: skill
+    attributes:
+      label: Skill name
+      description: The skill directory name, exactly as it appears under `skills/`.
+      placeholder: transformers
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What needs improving
+      multiple: true
+      options:
+        - Outdated API or deprecated calls
+        - Missing workflow or capability
+        - Examples are wrong, untested, or too thin
+        - Instructions are ambiguous for an agent
+        - Description triggers too often or not often enough
+        - Missing or broken references
+        - Missing tests
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+      description: What does the skill say or do today? Quote the relevant part of `SKILL.md` or a reference file, with the file path.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed change
+      description: What should it say or do instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Supporting sources
+      description: Upstream release notes, migration guides, or docs that show the current content is out of date.
+      placeholder: |
+        - Changelog: https://...
+        - Migration guide: https://...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you like to make this change?
+      options:
+        - "Yes — I plan to open a pull request"
+        - "Maybe, with some guidance"
+        - "No, I am reporting it"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,68 @@
+# Summary
+
+<!-- What changed, and why it matters. One or two sentences is fine. -->
+
+## Type of change
+
+<!-- Keep the lines that apply, delete the rest. -->
+
+- [ ] New skill
+- [ ] Update to an existing skill
+- [ ] Tests
+- [ ] Repository tooling or CI
+- [ ] Documentation
+- [ ] Other:
+
+## Skills touched
+
+<!-- Directory names under skills/, one per line. Write "none" if this PR does not touch skills/. -->
+
+-
+
+## How this was tested
+
+<!-- The commands you ran and what they reported. -->
+
+```
+uv run skills-ref validate ./skills/<name>
+uv run --with pytest python -m pytest tests/<name> -q
+```
+
+## Related issues and references
+
+<!-- Closes #123. Link upstream docs, release notes, or security findings that justify the change. -->
+
+---
+
+## Checklist
+
+Drawn from the [Pull Request Checklist](https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/CONTRIBUTING.md#pull-request-checklist) in CONTRIBUTING.md. Items that do not apply to this PR can be left unchecked with a short note.
+
+**Skill format**
+
+- [ ] The skill directory name and the `name` frontmatter match exactly.
+- [ ] The skill directory contains only `SKILL.md`, `references/`, `scripts/`, and `assets/` — no `tests/` directory and no `test_*.py` files.
+- [ ] `SKILL.md` has valid YAML frontmatter and a Markdown body.
+- [ ] Only the six spec-defined top-level fields are present; everything else lives under `metadata`.
+- [ ] `metadata` is a block mapping, not single-line JSON, and scalar values are quoted where needed.
+- [ ] Any `metadata.openclaw` or `metadata.hermes` block is a nested mapping, not a JSON string.
+- [ ] `metadata.version` exists, is quoted, and is bumped if an existing skill changed.
+- [ ] The `description` says both what the skill does and when an agent should use it.
+
+**Validation and tests**
+
+- [ ] `uv run skills-ref validate ./skills/<name>` passes.
+- [ ] Tests live in `tests/<skill-name>/`, and any new `scripts/` skill has a `[skills.<name>]` entry in `tests/skill-requirements.toml`.
+- [ ] Relevant test suites pass, or the failures are explained below.
+- [ ] Security scanner results are clean or explained in this PR.
+
+**Content and safety**
+
+- [ ] Examples and scripts were tested, or are clearly marked as illustrative.
+- [ ] No secrets, credentials, private data, or unsafe instructions are included.
+- [ ] Credentials the skill needs are named in `compatibility` and declared in `metadata.openclaw.envVars`.
+- [ ] Relevant official documentation is linked where useful.
+
+## Notes for reviewers
+
+<!-- Anything unresolved, deliberately out of scope, or worth a closer look. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,135 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[contact@k-dense.ai](mailto:contact@k-dense.ai).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+Note that this address is for conduct reports. Security vulnerabilities follow a
+separate, confidential process — see [SECURITY.md](SECURITY.md).
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/inclusion
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for helping improve Scientific Agent Skills. This guide explains how to add or update a skill in this repository while following the open [Agent Skills specification](https://agentskills.io/specification).
 
+Participation in this project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Ways to Contribute
 
 - Add a new scientific package, database, platform, workflow, or research method skill.


### PR DESCRIPTION
Completes the three GitHub Community Standards items the repository was missing. `gh api repos/K-Dense-AI/scientific-agent-skills/community/profile` currently reports `health_percentage: 75` with `code_of_conduct`, `issue_template`, and `pull_request_template` all `null`.

## What's here

**`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, unmodified except for the enforcement contact (`contact@k-dense.ai`) and a note directing security vulnerabilities to `SECURITY.md` rather than the conduct address.

**`.github/ISSUE_TEMPLATE/`** — three YAML issue forms and a config:

| Template | Labels | Purpose |
|---|---|---|
| `bug_report.yml` | `bug`, `needs-triage` | Wrong output, broken script, failing install, instructions an agent can't follow. Collects agent host + model, since skill behavior varies by host. |
| `new_skill_request.yml` | `enhancement`, `skill-request`, `needs-triage` | Asks for the "what it does" and "when to use it" halves of a skill description, plus official docs and credential requirements. |
| `skill_improvement.yml` | `enhancement`, `needs-triage` | Stale APIs, thin examples, descriptions that trigger at the wrong time. |

`config.yml` sets `blank_issues_enabled: false` and adds contact links to private vulnerability reporting, `CONTRIBUTING.md`, the Agent Skills specification, and the K-Dense docs. Discussions are disabled on this repository, so nothing links there.

**`.github/PULL_REQUEST_TEMPLATE.md`** — summary, type of change, skills touched, how it was tested, and a checklist grouped into skill format / validation and tests / content and safety. The checklist items are taken from the existing Pull Request Checklist in `CONTRIBUTING.md` rather than invented, so there is one source of truth to keep in sync.

**`CONTRIBUTING.md`** — one added line linking the Code of Conduct.

## Notes

- Two labels referenced by the templates did not exist and were created ahead of this PR: `needs-triage` (`#ededed`) and `skill-request` (`#1d76db`). All other labels used were already present.
- All four YAML files parse and conform to GitHub's issue-form schema (validated locally: allowed `type` values, `id`/`label` present on every non-markdown block, non-empty `options` on every dropdown).
- Nothing under `skills/` is touched, so the skill-spec and PR-scan workflows have no work to do here.
- The `health_percentage` will not move until this merges to `main`.